### PR TITLE
Fix OpenMP lock initialization issue in JIT mode

### DIFF
--- a/codon/sir/util/irtools.cpp
+++ b/codon/sir/util/irtools.cpp
@@ -115,7 +115,7 @@ VarValue *makeVar(Value *x, SeriesFlow *flow, BodiedFunc *parent, bool prepend) 
   auto *v = M->Nr<Var>(x->getType(), global);
   if (global) {
     static int counter = 1;
-    v->setName("_anon_global_" + std::to_string(counter++));
+    v->setName(".anon_global." + std::to_string(counter++));
   }
   auto *a = M->Nr<AssignInstr>(v, x);
   if (prepend) {

--- a/stdlib/openmp.codon
+++ b/stdlib/openmp.codon
@@ -126,13 +126,13 @@ def _reduction_loc():
 _reduction_loc()
 
 
-def _critical_begin(loc_ref: Ptr[Ident], gtid: int, lck: cobj):
-    from C import __kmpc_critical(Ptr[Ident], i32, cobj)
+def _critical_begin(loc_ref: Ptr[Ident], gtid: int, lck: Ptr[Lock]):
+    from C import __kmpc_critical(Ptr[Ident], i32, Ptr[Lock])
     __kmpc_critical(loc_ref, i32(gtid), lck)
 
 
-def _critical_end(loc_ref: Ptr[Ident], gtid: int, lck: cobj):
-    from C import __kmpc_end_critical(Ptr[Ident], i32, cobj)
+def _critical_end(loc_ref: Ptr[Ident], gtid: int, lck: Ptr[Lock]):
+    from C import __kmpc_end_critical(Ptr[Ident], i32, Ptr[Lock])
     __kmpc_end_critical(loc_ref, i32(gtid), lck)
 
 
@@ -325,12 +325,12 @@ def _reduce_nowait(
     gtid: int,
     reduce_data: T,
     reduce_func: cobj,
-    lck: cobj,
+    lck: Ptr[Lock],
     T: type,
 ):
     from internal.gc import sizeof
 
-    from C import __kmpc_reduce_nowait(Ptr[Ident], i32, i32, int, cobj, cobj, cobj) -> i32
+    from C import __kmpc_reduce_nowait(Ptr[Ident], i32, i32, int, cobj, cobj, Ptr[Lock]) -> i32
     num_vars = staticlen(reduce_data)
     reduce_size = sizeof(T)
     return int(
@@ -346,8 +346,8 @@ def _reduce_nowait(
     )
 
 
-def _end_reduce_nowait(loc_ref: Ptr[Ident], gtid: int, lck: cobj):
-    from C import __kmpc_end_reduce_nowait(Ptr[Ident], i32, cobj)
+def _end_reduce_nowait(loc_ref: Ptr[Ident], gtid: int, lck: Ptr[Lock]):
+    from C import __kmpc_end_reduce_nowait(Ptr[Ident], i32, Ptr[Lock])
     __kmpc_end_reduce_nowait(loc_ref, i32(gtid), lck)
 
 
@@ -875,11 +875,11 @@ def critical(func):
     def _wrapper(*args, **kwargs):
         gtid = get_thread_num()
         loc = _default_loc()
-        _critical_begin(loc, gtid, __ptr__(_default_lock).as_byte())
+        _critical_begin(loc, gtid, __ptr__(_default_lock))
         try:
             func(*args, **kwargs)
         finally:
-            _critical_end(loc, gtid, __ptr__(_default_lock).as_byte())
+            _critical_end(loc, gtid, __ptr__(_default_lock))
 
     return _wrapper
 


### PR DESCRIPTION
OpenMP locks are 32-byte buffers that are used by the runtime. Initially the OpenMP pass would allocate these as needed early in `main()`, but this doesn't work in JIT mode since `main()` will have already executed before the OpenMP pass is even applied. This PR changes locks to be global variables of type `Lock`, which is a 32-byte tuple (struct) defined in the `openmp` module; then, a pointer to this global variable is passed to OpenMP as the lock.

As a side note, the global-demotion IR pass demotes globals that are used in just one function. We need to make sure we don't demote this lock global, so we just add a dummy assignment of it to `main()`.

Fixes https://github.com/exaloop/codon/issues/29.