### PR TITLE
Constructing std::unique_ptr<Node> in place to improve performance for C++ binary trees benchmark

### DIFF
--- a/bench/binary_trees/binary_trees.cpp
+++ b/bench/binary_trees/binary_trees.cpp
@@ -13,13 +13,12 @@ struct Node {
 inline std::unique_ptr<Node> make_tree(int d) {
   if (d > 0) {
     return std::make_unique<Node>(Node{make_tree(d - 1), make_tree(d - 1)});
-  }
-  else {
+  } else {
     return std::make_unique<Node>();
   }
 }
 
-inline int check_tree(const std::unique_ptr<Node>& node) {
+inline int check_tree(const std::unique_ptr<Node> &node) {
   if (!node->left)
     return 1;
   else
@@ -62,10 +61,10 @@ int main(int argc, char *argv[]) {
   int n = std::stoi(argv[1]);
   int max_depth = std::max(min_depth + 2, n);
   int stretch_depth = max_depth + 1;
-  
+
   std::cout << "stretch tree of depth " << stretch_depth
             << "\t check: " << make_check({0, stretch_depth}) << '\n';
-  
+
   auto long_lived_tree = make_tree(max_depth);
   int mmd = max_depth + min_depth;
   for (int d = min_depth; d < stretch_depth; d += 2) {

--- a/bench/binary_trees/binary_trees.cpp
+++ b/bench/binary_trees/binary_trees.cpp
@@ -5,52 +5,54 @@
 #include <utility>
 #include <vector>
 
-struct Node {
-  std::unique_ptr<Node> left{};
-  std::unique_ptr<Node> right{};
-};
-
-inline std::unique_ptr<Node> make_tree(int d) {
-  if (d > 0) {
-    return std::make_unique<Node>(Node{make_tree(d - 1), make_tree(d - 1)});
-  }
-  else {
-    return std::make_unique<Node>();
-  }
-}
-
-inline int check_tree(const std::unique_ptr<Node>& node) {
-  if (!node->left)
-    return 1;
-  else
-    return 1 + check_tree(node->left) + check_tree(node->right);
-}
-
-inline int make_check(const std::pair<int, int> &itde) {
-  int i = itde.first, d = itde.second;
-  auto tree = make_tree(d);
-  return check_tree(tree);
-}
-
-struct ArgChunks {
-  int i, k, d, chunksize;
-  std::vector<std::pair<int, int>> chunk;
-
-  ArgChunks(int i, int d, int chunksize = 5000)
-      : i(i), k(1), d(d), chunksize(chunksize), chunk() {
-    assert(chunksize % 2 == 0);
-  }
-
-  bool next() {
-    chunk.clear();
-    while (k <= i) {
-      chunk.emplace_back(k++, d);
-      if (chunk.size() == chunksize)
-        return true;
+namespace {
+  struct Node {
+    std::unique_ptr<Node> left{};
+    std::unique_ptr<Node> right{};
+  };
+  
+  inline std::unique_ptr<Node> make_tree(int d) {
+    if (d > 0) {
+      return std::make_unique<Node>(Node{make_tree(d - 1), make_tree(d - 1)});
     }
-    return !chunk.empty();
+    else {
+      return std::make_unique<Node>();
+    }
   }
-};
+  
+  inline int check_tree(const std::unique_ptr<Node>& node) {
+    if (!node->left)
+      return 1;
+    else
+      return 1 + check_tree(node->left) + check_tree(node->right);
+  }
+  
+  inline int make_check(const std::pair<int, int> &itde) {
+    int i = itde.first, d = itde.second;
+    auto tree = make_tree(d);
+    return check_tree(tree);
+  }
+  
+  struct ArgChunks {
+    int i, k, d, chunksize;
+    std::vector<std::pair<int, int>> chunk;
+    
+    ArgChunks(int i, int d, int chunksize = 5000)
+    : i(i), k(1), d(d), chunksize(chunksize), chunk() {
+      assert(chunksize % 2 == 0);
+    }
+    
+    bool next() {
+      chunk.clear();
+      while (k <= i) {
+        chunk.emplace_back(k++, d);
+        if (chunk.size() == chunksize)
+          return true;
+      }
+      return !chunk.empty();
+    }
+  };
+} // namespace
 
 int main(int argc, char *argv[]) {
   using clock = std::chrono::high_resolution_clock;

--- a/bench/binary_trees/binary_trees.cpp
+++ b/bench/binary_trees/binary_trees.cpp
@@ -6,30 +6,29 @@
 #include <vector>
 
 struct Node {
-  Node* left{};
-  Node* right{};
+  std::unique_ptr<Node> left{};
+  std::unique_ptr<Node> right{};
 };
 
-inline Node* make_tree(int d, std::vector<Node>& pool) {
+inline std::unique_ptr<Node> make_tree(int d) {
   if (d > 0) {
-    return &pool.emplace_back(Node{make_tree(d - 1, pool), make_tree(d - 1, pool)});
+    return std::make_unique<Node>(Node{make_tree(d - 1), make_tree(d - 1)});
   }
   else {
-    return &pool.emplace_back(Node{});
+    return std::make_unique<Node>();
   }
 }
 
-inline int check_tree(const Node* node) {
+inline int check_tree(const std::unique_ptr<Node>& node) {
   if (!node->left)
     return 1;
   else
     return 1 + check_tree(node->left) + check_tree(node->right);
 }
 
-inline int make_check(const std::pair<int, int> &itde, std::vector<Node>& pool) {
+inline int make_check(const std::pair<int, int> &itde) {
   int i = itde.first, d = itde.second;
-  pool.clear();
-  auto tree = make_tree(d, pool);
+  auto tree = make_tree(d);
   return check_tree(tree);
 }
 
@@ -64,12 +63,10 @@ int main(int argc, char *argv[]) {
   int max_depth = std::max(min_depth + 2, n);
   int stretch_depth = max_depth + 1;
   
-  std::vector<Node> pool{};
-
   std::cout << "stretch tree of depth " << stretch_depth
-            << "\t check: " << make_check({0, stretch_depth}, pool) << '\n';
+            << "\t check: " << make_check({0, stretch_depth}) << '\n';
   
-  auto long_lived_tree = make_tree(max_depth, pool);
+  auto long_lived_tree = make_tree(max_depth);
   int mmd = max_depth + min_depth;
   for (int d = min_depth; d < stretch_depth; d += 2) {
     int i = (1 << (mmd - d));
@@ -77,7 +74,7 @@ int main(int argc, char *argv[]) {
     ArgChunks iter(i, d);
     while (iter.next()) {
       for (auto &argchunk : iter.chunk) {
-        cs += make_check(argchunk, pool);
+        cs += make_check(argchunk);
       }
     }
     std::cout << i << "\t trees of depth " << d << "\t check: " << cs << '\n';

--- a/bench/binary_trees/binary_trees.cpp
+++ b/bench/binary_trees/binary_trees.cpp
@@ -5,54 +5,52 @@
 #include <utility>
 #include <vector>
 
-namespace {
-  struct Node {
-    std::unique_ptr<Node> left{};
-    std::unique_ptr<Node> right{};
-  };
-  
-  inline std::unique_ptr<Node> make_tree(int d) {
-    if (d > 0) {
-      return std::make_unique<Node>(Node{make_tree(d - 1), make_tree(d - 1)});
-    }
-    else {
-      return std::make_unique<Node>();
-    }
+struct Node {
+  std::unique_ptr<Node> left{};
+  std::unique_ptr<Node> right{};
+};
+
+inline std::unique_ptr<Node> make_tree(int d) {
+  if (d > 0) {
+    return std::make_unique<Node>(Node{make_tree(d - 1), make_tree(d - 1)});
   }
-  
-  inline int check_tree(const std::unique_ptr<Node>& node) {
-    if (!node->left)
-      return 1;
-    else
-      return 1 + check_tree(node->left) + check_tree(node->right);
+  else {
+    return std::make_unique<Node>();
   }
-  
-  inline int make_check(const std::pair<int, int> &itde) {
-    int i = itde.first, d = itde.second;
-    auto tree = make_tree(d);
-    return check_tree(tree);
+}
+
+inline int check_tree(const std::unique_ptr<Node>& node) {
+  if (!node->left)
+    return 1;
+  else
+    return 1 + check_tree(node->left) + check_tree(node->right);
+}
+
+inline int make_check(const std::pair<int, int> &itde) {
+  int i = itde.first, d = itde.second;
+  auto tree = make_tree(d);
+  return check_tree(tree);
+}
+
+struct ArgChunks {
+  int i, k, d, chunksize;
+  std::vector<std::pair<int, int>> chunk;
+
+  ArgChunks(int i, int d, int chunksize = 5000)
+      : i(i), k(1), d(d), chunksize(chunksize), chunk() {
+    assert(chunksize % 2 == 0);
   }
-  
-  struct ArgChunks {
-    int i, k, d, chunksize;
-    std::vector<std::pair<int, int>> chunk;
-    
-    ArgChunks(int i, int d, int chunksize = 5000)
-    : i(i), k(1), d(d), chunksize(chunksize), chunk() {
-      assert(chunksize % 2 == 0);
+
+  bool next() {
+    chunk.clear();
+    while (k <= i) {
+      chunk.emplace_back(k++, d);
+      if (chunk.size() == chunksize)
+        return true;
     }
-    
-    bool next() {
-      chunk.clear();
-      while (k <= i) {
-        chunk.emplace_back(k++, d);
-        if (chunk.size() == chunksize)
-          return true;
-      }
-      return !chunk.empty();
-    }
-  };
-} // namespace
+    return !chunk.empty();
+  }
+};
 
 int main(int argc, char *argv[]) {
   using clock = std::chrono::high_resolution_clock;


### PR DESCRIPTION
Codon uses garbage collection, so I feel like this problem should permit using a memory pool, as would be common in this kind of problem. There are other ways to make the original code faster without a pool, but I think this makes the most sense.