### PR TITLE
UInt[N] constructor bugfix

### DIFF
--- a/stdlib/internal/types/intn.codon
+++ b/stdlib/internal/types/intn.codon
@@ -260,7 +260,7 @@ class UInt:
         elif N == 64:
             return UInt[N](Int[N](what))
         else:
-            return UInt[N](__internal__.int_zext(what, 64, N))
+            return UInt[N](__internal__.int_sext(what, 64, N))
 
     @pure
     @llvm

--- a/test/core/arithmetic.codon
+++ b/test/core/arithmetic.codon
@@ -25,7 +25,8 @@ def test_popcnt():
     assert (0).popcnt() == 0
     assert int.popcnt(-1) == 64
     assert u8(-1).popcnt() == 8
-    assert (UInt[1024](0xfffffffffffffff3) * UInt[1024](0xfffffffffffffff3)).popcnt() == 65
+    assert (UInt[1024](0xfffffffffffffff3) * UInt[1024](0xfffffffffffffff3)).popcnt() == 4
+    assert UInt[128](-1).popcnt() == 128
 test_popcnt()
 
 @test


### PR DESCRIPTION
- `UInt[N](-1)` returns the wrong result.
- The problem is zero-extending the `int` before casting it to `UInt`.