### PR TITLE
Fix error when `libpython` doesn't exists

### DIFF
--- a/stdlib/internal/python.codon
+++ b/stdlib/internal/python.codon
@@ -348,6 +348,7 @@ def setup_python(python_loaded: bool):
         py_handle = dlopen("", RTLD_LOCAL | RTLD_NOW)
     else:
         LD = os.getenv("CODON_PYTHON", default="libpython." + dlext())
+        assert os.path.exists(LD)
         py_handle = dlopen(LD, RTLD_LOCAL | RTLD_NOW)
 
     init_dl_handles(py_handle)

--- a/stdlib/os/path.codon
+++ b/stdlib/os/path.codon
@@ -18,3 +18,15 @@ def splitext(p: str) -> Tuple[str, str]:
                 return p[:dotIndex], p[dotIndex:]
             filenameIndex += 1
     return p, p[:0]
+    
+def exists(path:str):
+    """
+    Returns True if path exists, False otherwise
+    """
+    from C import fopen(a:cobj,b:cobj)->cobj
+    from C import fclose(a:cobj)->int
+    ret = fopen(path.ptr,"r")
+    if ret:
+        fclose(ret)
+        return True
+    return False


### PR DESCRIPTION
`./codon run <(echo 'import python')`
```
CError: libpython.so: cannot open shared object file: No such file or directory

Raised from: std.internal.dlopen.dlopen.2:0
/home/marat/.codon/lib/codon/stdlib/internal/dlopen.codon:31:9

Backtrace:
  [0x7f91bd93a8cf] GCC_except_table146 at /home/marat/.codon/lib/codon/stdlib/internal/dlopen.codon:31:9
  [0x7f91bd93f2ea] GCC_except_table146 at /home/marat/.codon/lib/codon/stdlib/internal/python.codon:351:45
  [0x7f91bd93f34a] GCC_except_table146 at /home/marat/.codon/lib/codon/stdlib/internal/python.codon:361:18
  [0x7f91bd93f3ad] GCC_except_table146 at /dev/fd/63:360:46
  [0x7f91bd9405dc] GCC_except_table146 at /dev/fd/63:1:1
```
Adding assert should help: user will see `AssertaionError`
