### PR TITLE
Fix GCMapAllocator not being used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,10 @@
 *.pyc
 build/
 build_*/
+build-*/
 install/
 install_*/
+install-*/
 extra/python/src/jit.cpp
 extra/jupyter/build/
 

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ Thumbs.db
 .idea
 .mypy_cache
 .vscode
+.cache
 
 extra/jupyter/share/jupyter/kernels/codon/kernel.json
 extra/python/codon/version.py


### PR DESCRIPTION
Previously, the GCMapAllocator specified the wrong template arguments and, thus, would not actually be used. This can be verified by the fact that `GCMapAllocator::deallocate` used an undefined symbol: `seq_gc_free`.

C++20 makes this an error like so:
```
error: static assertion failed due to requirement 'is_same<GCMapAllocator<std::pair<seq_str_t, long long>, re2::RE2>, GCMapAllocator<std::pair<const std::pair<seq_str_t, long long>, re2::RE2>, re2::RE2>>::value': [allocator.requirements] states that rebinding an allocator to the same type should result in the original allocator
    static_assert(is_same<allocator_type, __rebind_alloc<__alloc_traits, value_type> >::value,
    ^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
3 errors generated.
```

This patch fixes the undefined symbol of `seq_gc_free` with `seq_free` along with fixing `<Key, Value>` -> `<std::pair<Key, Value>>`.