### PR TITLE
Add a Dependabot config to keep GitHub action versions updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Several GitHub action versions are out of date and are throwing deprecation warnings due to their use of Node 12 ([recent example](https://github.com/exaloop/codon/actions/runs/6088334024)).

Rather than update the actions once, this PR introduce a Dependabot config that will open PRs to automatically update the versions on a monthly basis.

If merged, you can expect that Dependabot will open several PRs immediately to address the out-of-date action versions (like `actions/checkout@v2`; latest version is `v4`).