### PR TITLE
Use kebab case, not snake case, for PyPI input keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,8 +238,8 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_TEST_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
-          skip_existing: true
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
 
       - name: Publish Package
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && startsWith(matrix.os, 'ubuntu')


### PR DESCRIPTION
The upload-to-PyPI CI action has migrated to kebab case, and notes this as a warning each time it runs ([recent example](https://github.com/exaloop/codon/actions/runs/6398395271)).

Note that this repo should migrate to Trusted Publishers instead of using an API token (the CI run linked above displays a warning about this, too). However, migrating to Trusted Publishers will require a maintainer with PyPI access to take action. [PyPI documents how to accomplish this](https://docs.pypi.org/trusted-publishers).