### PR TITLE
Update the applicable bash profile file

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -50,6 +50,10 @@ if [[ "$SHELL" == *zsh ]]; then
 elif [[ "$SHELL" == *bash ]]; then
   if [ -e ~/.bash_profile ]; then
     update_profile ~/.bash_profile
+  elif [ -e ~/.bash_login ]; then
+    update_profile ~/.bash_login
+  elif [ -e ~/.profile ]; then
+    update_profile ~/.profile
   else
     echo "Could not find bash configuration file to update PATH"
   fi


### PR DESCRIPTION
Update the bash profile in ~/.bash_login or ~/.profile, if exists.

A bash interactive login shell "looks for ~/.bash_profile, ~/.bash_login, and ~/.profile, in that order, and reads and executes commands from the first one that exists and is readable."