### PR TITLE
Fix accessing imported modules’ globals in list comprehensions

### DIFF
--- a/codon/parser/visitors/simplify/collections.cpp
+++ b/codon/parser/visitors/simplify/collections.cpp
@@ -59,7 +59,7 @@ void SimplifyVisitor::visit(GeneratorExpr *expr) {
   bool canOptimize = expr->kind == GeneratorExpr::ListGenerator && loops.size() == 1 &&
                      loops[0].conds.empty();
   if (canOptimize) {
-    auto iter = transform(loops[0].gen);
+    auto iter = transform(loops[0].gen->clone());
     IdExpr *id;
     if (iter->getCall() && (id = iter->getCall()->expr->getId())) {
       // Turn off this optimization for static items

--- a/test/core/generators.codon
+++ b/test/core/generators.codon
@@ -108,3 +108,10 @@ def test_generator_in_finally():
         assert e.message == 'not n'
     assert b
 test_generator_in_finally()
+
+
+@test
+def test_imported_in_list_comprehension():
+    import string
+    assert [x for x in string.digits] == list("0123456789")
+test_imported_in_list_comprehension()


### PR DESCRIPTION
What I hope is a correct fix for a bug I encountered with this code:

```python
import sys

bwt = [
    "" if c == "$" else c
    for c in sys.argv[1]
]
```

```
burrow.codon:42:14-25: error: name 'argv' is not defined
```