### PR TITLE
Add os.environ.setdefault(str, str) functionality

### DIFF
--- a/stdlib/os/__init__.codon
+++ b/stdlib/os/__init__.codon
@@ -51,6 +51,10 @@ class EnvMap:
         self._init_if_needed()
         return self._map.items()
 
+    def setdefault(self, key: str, default: str = "") -> str:
+        self._init_if_needed()
+        return self._map.setdefault(key, default)
+
 environ = EnvMap()
 
 def getenv(key: str, default: str = "") -> str:

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -475,6 +475,7 @@ INSTANTIATE_TEST_SUITE_P(
         "stdlib/sort_test.codon",
         "stdlib/heapq_test.codon",
         "stdlib/operator_test.codon",
+        "stdlib/os_test.codon",
         "python/pybridge.codon"
       ),
       testing::Values(true, false),

--- a/test/stdlib/os_test.codon
+++ b/test/stdlib/os_test.codon
@@ -1,0 +1,11 @@
+import os
+
+@test
+def test_environ_setdefault():
+    rnd_env_key = "RND_KZBAF"
+    assert os.environ.setdefault(rnd_env_key, "VALUE_1") == "VALUE_1"
+    assert os.environ[rnd_env_key] == "VALUE_1"
+    assert os.environ.setdefault(rnd_env_key, "VALUE_2") == "VALUE_1"
+    assert os.environ[rnd_env_key] == "VALUE_1"
+
+test_environ_setdefault()


### PR DESCRIPTION
Implements `os.environ.setdefault(key, default = "")` functionality as in python (closes #583).

Set the value of the `key` environment variable to `default` if it did not exist and return it.
Return the value from the environment if it was already set.

```
import os

a = os.environ.setdefault("A", "default_value")
```