### PR TITLE
Add an option to open() the file descriptor

### DIFF
--- a/stdlib/internal/file.codon
+++ b/stdlib/internal/file.codon
@@ -18,7 +18,7 @@ class File:
         self._reset()
 
     def __init__(self, fd: int, mode: str):
-        self.fp = _C.fdopen(fd, mode.c_str()) 
+        self.fp = _C.fdopen(fd, mode.c_str())
         if not self.fp:
             raise IOError(f"file descriptor {fd} could not be opened")
         self._reset()

--- a/stdlib/internal/file.codon
+++ b/stdlib/internal/file.codon
@@ -17,6 +17,12 @@ class File:
             raise IOError(f"file {path} could not be opened")
         self._reset()
 
+    def __init__(self, fd: int, mode: str):
+        self.fp = _C.fdopen(fd, mode.c_str()) 
+        if not self.fp:
+            raise IOError(f"file descriptor {fd} could not be opened")
+        self._reset()
+
     def _errcheck(self, msg: str):
         err = int(_C.ferror(self.fp))
         if err:
@@ -394,6 +400,9 @@ class bzFile:
 
 def open(path: str, mode: str = "r") -> File:
     return File(path, mode)
+
+def open(fd: int, mode: str = "r") -> File:
+    return File(fd, mode)
 
 def gzopen(path: str, mode: str = "r") -> gzFile:
     return gzFile(path, mode)


### PR DESCRIPTION
This PR adds an option (overload) to the open() builtin function to allow opening the file descriptors (as in python).

Useful when you want to read from the standard input:

```python
# app.codon
for line in open(0):
    print(line)
```
then:
```
codon run app.codon < input.txt
```