### PR TITLE
Fix link to multithreading docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ print(total)
 ```
 
 Note that Codon automatically turns the `total += 1` statement in the loop body into an atomic
-reduction to avoid race conditions. Learn more in the [multitheading docs](advanced/parallel.md).
+reduction to avoid race conditions. Learn more in the [multithreading docs](docs/advanced/parallel.md).
 
 Codon also supports writing and executing GPU kernels. Here's an example that computes the
 [Mandelbrot set](https://en.wikipedia.org/wiki/Mandelbrot_set):


### PR DESCRIPTION
Hello there,

I've noticed that the link to the parallelism docs on the repo's README is both containing a typo in the word "multithreading" and doesn't work at all (as the docs have been moved to `docs/`).

This patch fixes said broken link.

Thank you very much for this nice project. Best regards!