### PR TITLE
Fix object file generation on release mode

### DIFF
--- a/codon/cir/llvm/llvisitor.cpp
+++ b/codon/cir/llvm/llvisitor.cpp
@@ -376,7 +376,7 @@ void LLVMVisitor::writeToObjectFile(const std::string &filename, bool pic) {
 
   llvm::TargetLibraryInfoImpl tlii(llvm::Triple(M->getTargetTriple()));
   pm.add(new llvm::TargetLibraryInfoWrapperPass(tlii));
-  if (!machine->addPassesToEmitFile(pm, *os, nullptr, llvm::CGFT_ObjectFile,
+  if (machine->addPassesToEmitFile(pm, *os, nullptr, llvm::CGFT_ObjectFile,
                                     /*DisableVerify=*/true, mmiwp))
     seqassertn(false, "could not add passes");
   const_cast<llvm::TargetLoweringObjectFile *>(llvmtm.getObjFileLowering())


### PR DESCRIPTION
seqassertn will not evaluate the firtst paramter when NDEBUG is on:
```cpp
#ifndef NDEBUG
#define seqassertn(expr, msg, ...)                                                     \
  ((expr) ? (void)(0)                                                                  \
          : codon::assertionFailure(#expr, __FILE__, __LINE__,                         \
                                    fmt::format(msg, ##__VA_ARGS__)))
#define seqassert(expr, msg, ...)                                                      \
  ((expr) ? (void)(0)                                                                  \
          : codon::assertionFailure(                                                   \
                #expr, __FILE__, __LINE__,                                             \
                fmt::format(msg " [{}]", ##__VA_ARGS__, getSrcInfo())))
#else
#define seqassertn(expr, msg, ...) ;
#define seqassert(expr, msg, ...) ;
#endif
```
Thus this code will not actually add any pass into the pass manager, 
```cpp
seqassertn(!machine->addPassesToEmitFile(pm, *os, nullptr, llvm::CGFT_ObjectFile,
                                           /*DisableVerify=*/true, mmiwp),
             "could not add passes");
```
which causes an empty .o or .so file generated
```txt
ld: test3.so.o: file not recognized: file truncated
collect2: error: ld returned 1 exit status
```