### PR TITLE
Remove duplicate header entry

### DIFF
--- a/codon/runtime/lib.h
+++ b/codon/runtime/lib.h
@@ -91,7 +91,6 @@ SEQ_FUNC void seq_print(seq_str_t str);
 SEQ_FUNC void seq_print_full(seq_str_t str, FILE *fo);
 
 SEQ_FUNC void *seq_lock_new();
-SEQ_FUNC void *seq_lock_new();
 SEQ_FUNC bool seq_lock_acquire(void *lock, bool block, double timeout);
 SEQ_FUNC void seq_lock_release(void *lock);
 SEQ_FUNC void *seq_rlock_new();


### PR DESCRIPTION
This simply removes a duplicate entry in the [codon/runtime/lib.h](https://github.com/exaloop/codon/blob/adb3da941640f29934a9710feea22d4053f90879/codon/runtime/lib.h#L93-L94) file.