### PR TITLE
Fix auto deduce of class member

### DIFF
--- a/codon/parser/ast/expr.h
+++ b/codon/parser/ast/expr.h
@@ -23,6 +23,7 @@ namespace codon::ast {
   void accept(VISITOR &visitor) override;                                              \
   std::string toString(int) const override;                                            \
   friend class TypecheckVisitor;                                                       \
+  friend class AutoDeduceMembersTypecheckVisitor;                                      \
   template <typename TE, typename TS> friend struct CallbackASTVisitor;                \
   friend struct ReplacingCallbackASTVisitor;                                           \
   inline decltype(auto) match_members() const { return std::tie(__VA_ARGS__); }        \
@@ -51,6 +52,8 @@ struct Expr : public AcceptorExtend<Expr, ASTNode> {
   void setDone() { done = true; }
   Expr *getOrigExpr() const { return origExpr; }
   void setOrigExpr(Expr *orig) { origExpr = orig; }
+  Expr *getTypeExpr() const { return typeExpr; }
+  void setTypeExpr(Expr *type) { typeExpr = type; }
 
   static const char NodeId;
   SERIALIZE(Expr, BASE(ASTNode), /*type,*/ done, origExpr);
@@ -69,6 +72,8 @@ private:
   bool done;
   /// Original (pre-transformation) expression
   Expr *origExpr;
+  /// the expression of type
+  Expr *typeExpr{nullptr};
 };
 
 /// Function signature parameter helper node (name: type = defaultValue).

--- a/codon/parser/ast/stmt.h
+++ b/codon/parser/ast/stmt.h
@@ -21,6 +21,7 @@ namespace codon::ast {
   void accept(VISITOR &visitor) override;                                              \
   std::string toString(int) const override;                                            \
   friend class TypecheckVisitor;                                                       \
+  friend class AutoDeduceMembersTypecheckVisitor;                                      \
   template <typename TE, typename TS> friend struct CallbackASTVisitor;                \
   friend struct ReplacingCallbackASTVisitor;                                           \
   inline decltype(auto) match_members() const { return std::tie(__VA_ARGS__); }        \

--- a/codon/parser/visitors/typecheck/typecheck.cpp
+++ b/codon/parser/visitors/typecheck/typecheck.cpp
@@ -1924,4 +1924,140 @@ ir::PyFunction TypecheckVisitor::cythonizeFunction(const std::string &name) {
   return {"", ""};
 }
 
+void AutoDeduceMembersTypecheckVisitor::visit(BoolExpr *exp) {
+  exp->setTypeExpr(N<IdExpr>("bool"));
+}
+
+void AutoDeduceMembersTypecheckVisitor::visit(IntExpr *exp) {
+  exp->setTypeExpr(N<IdExpr>("int"));
+}
+
+void AutoDeduceMembersTypecheckVisitor::visit(FloatExpr *exp) {
+  exp->setTypeExpr(N<IdExpr>("float"));
+}
+
+void AutoDeduceMembersTypecheckVisitor::visit(StringExpr *exp) {
+  exp->setTypeExpr(N<IdExpr>("str"));
+}
+
+void AutoDeduceMembersTypecheckVisitor::visit(IdExpr *exp) {
+  auto val = exp->getValue();
+  auto it = std::find_if(args.begin(), args.end(), 
+                         [val](Param &arg) { return arg.name == val; });
+  if (it != args.end()) {
+    exp->setTypeExpr(it->getType());
+  }
+}
+
+void AutoDeduceMembersTypecheckVisitor::visit(TupleExpr *exp) {
+  std::vector<Expr *> items;
+  for (auto e : exp->items) {
+    e->accept(*this);
+    items.push_back(e->getTypeExpr());
+  }
+  auto tupleExpr = N<TupleExpr>(items);
+  auto idExpr = N<IdExpr>("Tuple");
+  exp->setTypeExpr(N<IndexExpr>(idExpr, tupleExpr));
+}
+
+void AutoDeduceMembersTypecheckVisitor::visit(ListExpr *exp) {
+  if (exp->items.empty())
+    return;
+  exp->items[0]->accept(*this);
+  auto listExpr = N<IdExpr>("List");
+  exp->setTypeExpr(N<IndexExpr>(listExpr, exp->items[0]->getTypeExpr()));
+}
+
+void AutoDeduceMembersTypecheckVisitor::visit(SetExpr *exp) {
+  if (exp->items.empty())
+    return;
+  exp->items[0]->accept(*this);
+  auto setExpr = N<IdExpr>("set");
+  exp->setTypeExpr(N<IndexExpr>(setExpr, exp->items[0]->getTypeExpr()));
+}
+
+void AutoDeduceMembersTypecheckVisitor::visit(DictExpr *exp) {
+  std::vector<Expr *> items;
+  for (auto e : exp->items) {
+    e->accept(*this);
+    items.push_back(e->getTypeExpr());
+  }
+  auto tupleExpr = N<TupleExpr>(items);
+  auto dictExpr = N<IdExpr>("Dict");
+  exp->setTypeExpr(N<IndexExpr>(dictExpr, tupleExpr));
+}
+
+void AutoDeduceMembersTypecheckVisitor::visit(UnaryExpr *exp) {
+  if(exp->op == "not") {
+    exp->setTypeExpr(N<IdExpr>("bool"));
+  }
+  else if (exp->op == "+" || exp->op == "-" || exp->op == "~") {
+    exp->expr->accept(*this);
+    exp->setTypeExpr(exp->expr->getTypeExpr());
+  }
+  else {
+    exp->setTypeExpr(N<IdExpr>(exp->op));
+  }
+}
+
+void AutoDeduceMembersTypecheckVisitor::visit(BinaryExpr *exp) {
+  exp->lexpr->accept(*this);
+  exp->rexpr->accept(*this);
+  exp->setTypeExpr(mergeTypeExpr(exp->op, 
+                                 exp->lexpr->getTypeExpr(), 
+                                 exp->rexpr->getTypeExpr()));
+}
+
+void AutoDeduceMembersTypecheckVisitor::visit(RangeExpr *exp) {
+  exp->setTypeExpr(N<IdExpr>("range"));
+}
+
+void AutoDeduceMembersTypecheckVisitor::visit(GeneratorExpr *exp) {
+  if (exp->kind == GeneratorExpr::ListGenerator || exp->kind == GeneratorExpr::SetGenerator) {
+    if (auto forExpr = cast<ForStmt>(exp->loops)) {
+      if (auto iter = cast<CallExpr>(forExpr->getIter())) {
+        if (auto idExpr = cast<IdExpr>(iter->expr)) {
+          if (idExpr->value == "range") {
+            if (forExpr->getSuite()->items.size() == 1) {
+              if (auto expStm = cast<ExprStmt>(forExpr->getSuite()->items[0])) {
+                if (auto varExpr = cast<IdExpr>(forExpr->getVar())) {
+                  args.emplace_back(varExpr->value, N<IdExpr>("int"));
+                  expStm->expr->accept(*this);
+                  auto typ = exp->kind == GeneratorExpr::ListGenerator ? N<IdExpr>("List") : N<IdExpr>("set");
+                  exp->setTypeExpr(N<IndexExpr>(typ, expStm->expr->getTypeExpr()));
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+Expr *AutoDeduceMembersTypecheckVisitor::mergeTypeExpr(std::string op, Expr *l, Expr *r) {
+  if (l == nullptr || r == nullptr) {
+    return nullptr;
+  }
+  else if (op == "==" || op == "!=" || op == ">" || op == ">=" || op == "<" || op == "<=" 
+     || op == "is" || op == "is not" || op == "in" || op == "not in" || op == "and" || op == "or") {
+    return N<IdExpr>("bool");
+  }
+  else if (op == "&" || op == "|" || op == "^" || op == "<<" || op == ">>" || op == "//") {
+    return N<IdExpr>("int");
+  }
+  else if (op == "+" || op == "-" || op == "*" || op == "/" || op == "%" || op == "**") {
+    if (l->toString() == r->toString()) {
+      return l;
+    }
+    else if (l->toString() == "'float" || r->toString() == "'float") {
+      return N<IdExpr>("float");
+    }
+    else {
+      return N<IdExpr>("int");
+    }
+  }
+  return l;
+}
+
 } // namespace codon::ast


### PR DESCRIPTION
This MR is intended to resolve the issue with auto-deduced members in inheritance scenarios, as described in https://github.com/exaloop/codon/issues/687. We have constructed a simple typechecker for inferring member types. When performing type checking on a class, it infers the types of members in advance based on the right-hand side values of their initializations.