### PR TITLE
Fix auto deduce of class member

### DIFF
--- a/codon/parser/ast/expr.h
+++ b/codon/parser/ast/expr.h
@@ -23,6 +23,7 @@ namespace codon::ast {
   void accept(VISITOR &visitor) override;                                              \
   std::string toString(int) const override;                                            \
   friend class TypecheckVisitor;                                                       \
+  friend class AutoDeduceMembersTypecheckVisitor;                                      \
   template <typename TE, typename TS> friend struct CallbackASTVisitor;                \
   friend struct ReplacingCallbackASTVisitor;                                           \
   inline decltype(auto) match_members() const { return std::tie(__VA_ARGS__); }        \
@@ -51,6 +52,8 @@ struct Expr : public AcceptorExtend<Expr, ASTNode> {
   void setDone() { done = true; }
   Expr *getOrigExpr() const { return origExpr; }
   void setOrigExpr(Expr *orig) { origExpr = orig; }
+  Expr *getTypeExpr() const { return typeExpr; }
+  void setTypeExpr(Expr *type) { typeExpr = type; }
 
   static const char NodeId;
   SERIALIZE(Expr, BASE(ASTNode), /*type,*/ done, origExpr);
@@ -69,6 +72,8 @@ private:
   bool done;
   /// Original (pre-transformation) expression
   Expr *origExpr;
+  /// the expression of type
+  Expr *typeExpr{nullptr};
 };
 
 /// Function signature parameter helper node (name: type = defaultValue).

--- a/codon/parser/ast/stmt.h
+++ b/codon/parser/ast/stmt.h
@@ -21,6 +21,7 @@ namespace codon::ast {
   void accept(VISITOR &visitor) override;                                              \
   std::string toString(int) const override;                                            \
   friend class TypecheckVisitor;                                                       \
+  friend class AutoDeduceMembersTypecheckVisitor;                                      \
   template <typename TE, typename TS> friend struct CallbackASTVisitor;                \
   friend struct ReplacingCallbackASTVisitor;                                           \
   inline decltype(auto) match_members() const { return std::tie(__VA_ARGS__); }        \

--- a/codon/parser/visitors/typecheck/class.cpp
+++ b/codon/parser/visitors/typecheck/class.cpp
@@ -479,6 +479,61 @@ std::vector<TypePtr> TypecheckVisitor::parseBaseClasses(
   return asts;
 }
 
+Expr *TypecheckVisitor::inferMemberType(std::string member, FunctionStmt *f) {
+  if (f->items.empty())
+    return nullptr;
+  AutoDeduceMembersTypecheckVisitor v(ctx, f->items);
+  return inferMemberType(f->items[0].name, member, f->getSuite(), v);
+}
+Expr *TypecheckVisitor::inferMemberType(std::string self, std::string member,
+                                        Stmt *stmt,
+                                        AutoDeduceMembersTypecheckVisitor &v) {
+  Expr *rlt = nullptr;
+  if (auto suite = cast<SuiteStmt>(stmt)) {
+    for (auto *s : *suite)
+      if (auto typ = inferMemberType(self, member, s, v))
+        rlt = typ;
+  } else if (auto whileLoop = cast<WhileStmt>(stmt)) {
+    if (auto typ = inferMemberType(self, member, whileLoop->getSuite(), v))
+      rlt = typ;
+    if (auto typ = inferMemberType(self, member, whileLoop->getElse(), v))
+      rlt = typ;
+  } else if (auto forLoop = cast<ForStmt>(stmt)) {
+    if (auto typ = inferMemberType(self, member, forLoop->getSuite(), v))
+      rlt = typ;
+    if (auto typ = inferMemberType(self, member, forLoop->getElse(), v))
+      rlt = typ;
+  } else if (auto ifStmt = cast<IfStmt>(stmt)) {
+    if (auto typ = inferMemberType(self, member, ifStmt->getIf(), v))
+      rlt = typ;
+    if (auto typ = inferMemberType(self, member, ifStmt->getElse(), v))
+      rlt = typ;
+  } else if (auto matchStmt = cast<MatchStmt>(stmt)) {
+    for (auto &c : matchStmt->items)
+      if (auto typ = inferMemberType(self, member, c.getSuite(), v))
+        rlt = typ;
+  } else if (auto tryStmt = cast<TryStmt>(stmt)) {
+    if (auto typ = inferMemberType(self, member, tryStmt->getSuite(), v))
+      rlt = typ;
+    if (auto typ = inferMemberType(self, member, tryStmt->getElse(), v))
+      rlt = typ;
+    if (auto typ = inferMemberType(self, member, tryStmt->getFinally(), v))
+      rlt = typ;
+  } else if (auto assignStmt = cast<AssignStmt>(stmt)) {
+    auto rhs = clone(assignStmt->getRhs());
+    rhs->accept(v);
+    if (auto lhs = cast<DotExpr>(assignStmt->getLhs())) {
+      if (auto idExpr = cast<IdExpr>(lhs->getExpr())) {
+        if (idExpr->getValue() == self && lhs->getMember() == member)
+          rlt = rhs->getTypeExpr();
+      }
+    } else if (auto lhs = cast<IdExpr>(assignStmt->getLhs())) {
+      v.addVar(lhs->value, rhs->getTypeExpr());
+    }
+  }
+  return rlt;
+}
+
 /// Find the first __init__ with self parameter and use it to deduce class members.
 /// Each deduced member will be treated as generic.
 /// @example
@@ -493,13 +548,16 @@ std::vector<TypePtr> TypecheckVisitor::parseBaseClasses(
 /// @return the transformed init and the pointer to the original function.
 bool TypecheckVisitor::autoDeduceMembers(ClassStmt *stmt, std::vector<Param> &args) {
   std::set<std::string> members;
+  std::unordered_map<std::string, Expr *> member2type;
   for (const auto &sp : getClassMethods(stmt->suite))
     if (auto f = cast<FunctionStmt>(sp)) {
       if (f->name == "__init__")
         if (const auto b =
                 f->getAttribute<ir::StringListAttribute>(Attr::ClassDeduce)) {
-          for (const auto &m : b->values)
+          for (const auto &m : b->values) {
             members.insert(m);
+            member2type[m] = inferMemberType(m, f);
+          }
         }
     }
   if (!members.empty()) {
@@ -507,10 +565,14 @@ bool TypecheckVisitor::autoDeduceMembers(ClassStmt *stmt, std::vector<Param> &ar
     if (auto aa = stmt->getAttribute<ir::StringListAttribute>(Attr::ClassMagic))
       std::erase(aa->values, "init");
     for (auto m : members) {
-      auto genericName = fmt::format("T_{}", m);
-      args.emplace_back(genericName, N<IdExpr>(TYPE_TYPE), N<IdExpr>("NoneType"),
-                        Param::Generic);
-      args.emplace_back(m, N<IdExpr>(genericName));
+      if (auto typ = member2type[m]) {
+        args.emplace_back(m, typ);
+      } else {
+        auto genericName = fmt::format("T_{}", m);
+        args.emplace_back(genericName, N<IdExpr>(TYPE_TYPE), N<IdExpr>("NoneType"),
+                          Param::Generic);
+        args.emplace_back(m, N<IdExpr>(genericName));
+      }
     }
     return true;
   }

--- a/codon/parser/visitors/typecheck/typecheck.h
+++ b/codon/parser/visitors/typecheck/typecheck.h
@@ -16,6 +16,8 @@
 
 namespace codon::ast {
 
+class AutoDeduceMembersTypecheckVisitor;
+
 /**
  * Visitor that infers expression types and performs type-guided transformations.
  *
@@ -201,6 +203,8 @@ private:
                                                const std::string &, const Expr *,
                                                types::ClassType *);
   bool autoDeduceMembers(ClassStmt *, std::vector<Param> &);
+  Expr *inferMemberType(std::string, FunctionStmt *);
+  Expr *inferMemberType(std::string, std::string, Stmt *, AutoDeduceMembersTypecheckVisitor &);
   static std::vector<Stmt *> getClassMethods(Stmt *s);
   void transformNestedClasses(const ClassStmt *, std::vector<Stmt *> &,
                               std::vector<Stmt *> &, std::vector<Stmt *> &);
@@ -482,6 +486,37 @@ public:
   ir::Func *realizeIRFunc(types::FuncType *fn,
                           const std::vector<types::TypePtr> &generics = {});
   // types::Type *getType(const std::string &);
+};
+
+// A simpler typechecker to infer the member type in advance 
+// based on the initializing right-hand side values.
+// TODO: support method calls.
+class AutoDeduceMembersTypecheckVisitor : public ASTVisitor {
+public:
+  AutoDeduceMembersTypecheckVisitor(std::shared_ptr<TypeContext> ctx, std::vector<Param> &args) 
+    : ctx(ctx), args(args) {}
+  void addVar(std::string name, Expr *typ) { args.emplace_back(name, typ); }
+private:
+  template <typename Tn, typename... Ts> Tn *N(Ts &&...args) {
+    Tn *t = ctx->cache->N<Tn>(std::forward<Ts>(args)...);
+    return t;
+  }
+  std::shared_ptr<TypeContext> ctx;
+  std::vector<Param> args;
+  void visit(BoolExpr *) override;
+  void visit(IntExpr *) override;
+  void visit(FloatExpr *) override;
+  void visit(StringExpr *) override;
+  void visit(IdExpr *) override;
+  void visit(TupleExpr *) override;
+  void visit(ListExpr *) override;
+  void visit(SetExpr *) override;
+  void visit(DictExpr *) override;
+  void visit(UnaryExpr *) override;
+  void visit(BinaryExpr *) override;
+  void visit(RangeExpr *) override;
+  void visit(GeneratorExpr *) override;
+  Expr *mergeTypeExpr(std::string, Expr *, Expr *);
 };
 
 } // namespace codon::ast


### PR DESCRIPTION
This MR is intended to resolve the issue with auto-deduced members in inheritance scenarios, as described in https://github.com/exaloop/codon/issues/687. We have constructed a simple typechecker for inferring member types. When performing type checking on a class, it infers the types of members in advance based on the right-hand side values of their initializations.