### PR TITLE
Fix "done" method of generators.

### DIFF
--- a/stdlib/internal/types/generator.codon
+++ b/stdlib/internal/types/generator.codon
@@ -7,8 +7,10 @@ class Generator:
         pass
 
     def done(self) -> bool:
-        self.__resume__()
-        return self.__done__()
+        is_done = self.__done__()
+        if not is_done:
+            self.__resume__()
+        return is_done
 
     def next(self: Generator[T]) -> T:
         if isinstance(T, None):


### PR DESCRIPTION
Fix "done" method of generators as before it would segfault in debug mode when getting the next element when the iterator was finished.

    $ cat test_iter.codon
    b = [1, 2, 3]

    d = iter(b)
    print(min(d))
    print(d.done())
    print(min(d))

    $ /software/exaloop/codon/codon-0.19.4/bin/codon run test_iter.codon
    1
    Segmentation fault (core dumped)

    $ /software/exaloop/codon/codon-0.19.4_done_fix/bin/codon run test_iter.codon
    1
    True
    ValueError: min() arg is an empty sequence

    Raised from: std.internal.builtin.min.0:0
    /software/exaloop/codon/codon-0.19.4_pipe/lib/codon/stdlib/internal/builtin.codon:83:13

    Backtrace:
      [0x7f9950a9986f] std.internal.builtin.min.0:0[Tuple[Generator[int]],Optional[NoneType],Optional[NoneType]].851 at /software/exaloop/codon/codon-0.19.4_pipe/lib/codon/stdlib/internal/builtin.codon:83:13
      [0x7f9950a9e8d2] main.0 at /software/exaloop/codon/test_iter.codon:6:7
    Aborted (core dumped)

Fixes: https://github.com/exaloop/codon/issues/246