### PR TITLE
fix: disable SVE targets on all ARM64 platforms without SVE support

### DIFF
--- a/codon/runtime/numpy/loops.cpp
+++ b/codon/runtime/numpy/loops.cpp
@@ -2,7 +2,7 @@
 
 #include "codon/runtime/lib.h"
 
-#if defined(__linux__) && (defined(__aarch64__) || defined(__arm64__))
+#if (defined(__aarch64__) || defined(__arm64__)) && !defined(__ARM_FEATURE_SVE)
 #define HWY_DISABLED_TARGETS HWY_ALL_SVE
 #endif
 


### PR DESCRIPTION
## Summary
- Replaced the Linux-only SVE disable check with `__ARM_FEATURE_SVE`
- Correctly disables SVE on ARM64 platforms without SVE (e.g. Apple Silicon)

Fixes: #749 