### PR TITLE
update: highway to 1.3.0 and fix constexpr Lanes() usage

### DIFF
--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -172,7 +172,7 @@ endif()
 CPMAddPackage(
     NAME highway
     GITHUB_REPOSITORY "google/highway"
-    GIT_TAG 1.2.0
+    GIT_TAG 1.3.0
     EXCLUDE_FROM_ALL YES
     OPTIONS "HWY_ENABLE_CONTRIB ON"
             "HWY_ENABLE_EXAMPLES OFF"

--- a/codon/runtime/numpy/loops.cpp
+++ b/codon/runtime/numpy/loops.cpp
@@ -152,7 +152,7 @@ struct CosFunctor {
   static inline auto vector(const hn::ScalableTag<T> d, const V &v) {
     // Values outside of [-LIMIT, LIMIT] are not valid for SIMD version.
     const T LIMIT = limit<T>();
-    constexpr size_t L = hn::Lanes(d);
+    HWY_LANES_CONSTEXPR size_t L = hn::Lanes(d);
     T tmp[L];
     Store(v, d, tmp);
 
@@ -330,7 +330,7 @@ struct SinFunctor {
   static inline auto vector(const hn::ScalableTag<T> d, const V &v) {
     // Values outside of [-LIMIT, LIMIT] are not valid for SIMD version.
     const T LIMIT = limit<T>();
-    constexpr size_t L = hn::Lanes(d);
+    HWY_LANES_CONSTEXPR size_t L = hn::Lanes(d);
     T tmp[L];
     Store(v, d, tmp);
 
@@ -367,7 +367,7 @@ struct SinhFunctor {
   static inline auto vector(const hn::ScalableTag<T> d, const V &v) {
     // Values outside of [-LIMIT, LIMIT] are not valid for SIMD version.
     const T LIMIT = limit<T>();
-    constexpr size_t L = hn::Lanes(d);
+    HWY_LANES_CONSTEXPR size_t L = hn::Lanes(d);
     T tmp[L];
     Store(v, d, tmp);
 
@@ -414,7 +414,7 @@ struct HypotFunctor {
 template <typename T, typename F>
 void UnaryLoop(const T *in, size_t is, T *out, size_t os, size_t n) {
   const hn::ScalableTag<T> d;
-  constexpr size_t L = Lanes(d);
+  HWY_LANES_CONSTEXPR size_t L = hn::Lanes(d);
   T tmp[L];
   size_t i;
 
@@ -449,7 +449,7 @@ template <typename T, typename F>
 void BinaryLoop(const T *in1, size_t is1, const T *in2, size_t is2, T *out, size_t os,
                 size_t n) {
   const hn::ScalableTag<T> d;
-  constexpr size_t L = Lanes(d);
+  HWY_LANES_CONSTEXPR size_t L = hn::Lanes(d);
   T tmp1[L];
   T tmp2[L];
   size_t i;


### PR DESCRIPTION
## Summary
- Update Google Highway SIMD Library from 1.2.0 to 1.3.0 in `cmake/deps.cmake`
- Replace `constexpr` with `HWY_LANES_CONSTEXPR` for `hn::Lanes()` usage in `codon/runtime/numpy/loops.cpp`

## Testing
- No functional change. Results are identical before and after the update.

## Reference
- Highway: Add “optional constexpr” for `Lanes`  
 https://github.com/google/highway/commit/99bb05378be47b4c21baef4c8ff0db831a2a88f1 

Fixes #748 
Fixes #749 