### PR TITLE
Fix nvptx Kernel return type lowering

### DIFF
--- a/codon/cir/llvm/gpu.cpp
+++ b/codon/cir/llvm/gpu.cpp
@@ -698,6 +698,69 @@ getRequiredGVs(const std::vector<llvm::GlobalValue *> &kernels) {
   return std::vector<llvm::GlobalValue *>(keep.begin(), keep.end());
 }
 
+static bool isEmptyStructType(llvm::Type *ty) {
+  auto *st = llvm::dyn_cast<llvm::StructType>(ty);
+  return st && st->getNumElements() == 0;
+}
+
+static llvm::Function *normalizeKernelReturnToVoid(llvm::Function *F) {
+  if (!F || F->isDeclaration())
+    return F;
+  if (!F->hasFnAttribute("kernel"))
+    return F;
+  if (F->getReturnType()->isVoidTy()) {
+    return F;
+  }
+  if (!isEmptyStructType(F->getReturnType())) {
+    return F;
+  }
+
+  auto *M = F->getParent();
+  auto &C = M->getContext();
+  auto *oldTy = F->getFunctionType();
+
+  std::vector<llvm::Type *> argTys;
+  argTys.reserve(oldTy->getNumParams());
+  for (auto *argTy : oldTy->params())
+    argTys.push_back(argTy);
+
+  auto *newTy = llvm::FunctionType::get(llvm::Type::getVoidTy(C), argTys,
+                                        oldTy->isVarArg());
+  auto *G = llvm::Function::Create(newTy, F->getLinkage(), F->getAddressSpace(), "");
+  M->getFunctionList().insert(F->getIterator(), G);
+  G->takeName(F);
+  G->copyAttributesFrom(F);
+  G->setCallingConv(F->getCallingConv());
+  G->setVisibility(F->getVisibility());
+  G->setDLLStorageClass(F->getDLLStorageClass());
+  G->setUnnamedAddr(F->getUnnamedAddr());
+
+  G->splice(G->begin(), F);
+
+  auto newArg = G->arg_begin();
+  for (auto &oldArg : F->args()) {
+    newArg->setName(oldArg.getName());
+    oldArg.replaceAllUsesWith(&*newArg);
+    ++newArg;
+  }
+
+  llvm::SmallVector<llvm::ReturnInst *, 8> returns;
+  for (auto &BB : *G) {
+    if (auto *RI = llvm::dyn_cast<llvm::ReturnInst>(BB.getTerminator()))
+      returns.push_back(RI);
+  }
+
+  for (auto *RI : returns) {
+    llvm::IRBuilder<> B(RI);
+    B.CreateRetVoid();
+    RI->eraseFromParent();
+  }
+
+  seqassertn(F->use_empty(), "kernel still has uses after ABI normalization");
+  F->eraseFromParent();
+  return G;
+}
+
 std::string moduleToPTX(llvm::Module *M, std::vector<llvm::GlobalValue *> &kernels) {
   llvm::Triple triple(llvm::Triple::normalize(GPU_TRIPLE));
   llvm::TargetLibraryInfoImpl tlii(triple);
@@ -892,28 +955,32 @@ void applyGPUTransformations(llvm::Module *M, const std::string &ptxFilename) {
   std::unique_ptr<llvm::Module> clone = llvm::CloneModule(*M);
   clone->setTargetTriple(llvm::Triple::normalize(GPU_TRIPLE));
   clone->setDataLayout(GPU_DL);
-
   if (isFastMathOn()) {
     clone->addModuleFlag(llvm::Module::ModFlagBehavior::Override, "nvvm-reflect-ftz",
                          1);
   }
 
   llvm::NamedMDNode *nvvmAnno = clone->getOrInsertNamedMetadata("nvvm.annotations");
+  std::vector<llvm::Function *> kernelCandidates;
   std::vector<llvm::GlobalValue *> kernels;
-
+  
   for (auto &F : *clone) {
     if (!F.hasFnAttribute("kernel"))
       continue;
+    kernelCandidates.push_back(&F);
+  }
 
+  for (auto *F : kernelCandidates) {
+    auto *kernel = normalizeKernelReturnToVoid(F);
     llvm::Metadata *nvvmElem[] = {
-        llvm::ConstantAsMetadata::get(&F),
+        llvm::ConstantAsMetadata::get(kernel),
         llvm::MDString::get(context, "kernel"),
         llvm::ConstantAsMetadata::get(
             llvm::ConstantInt::get(llvm::Type::getInt32Ty(context), 1)),
     };
 
     nvvmAnno->addOperand(llvm::MDNode::get(context, nvvmElem));
-    kernels.push_back(&F);
+    kernels.push_back(kernel);
   }
 
   if (kernels.empty()) {

--- a/codon/cir/llvm/gpu.cpp
+++ b/codon/cir/llvm/gpu.cpp
@@ -698,22 +698,15 @@ getRequiredGVs(const std::vector<llvm::GlobalValue *> &kernels) {
   return std::vector<llvm::GlobalValue *>(keep.begin(), keep.end());
 }
 
-static bool isEmptyStructType(llvm::Type *ty) {
+bool isEmptyStructType(llvm::Type *ty) {
   auto *st = llvm::dyn_cast<llvm::StructType>(ty);
-  return st && st->getNumElements() == 0;
+  return st && !st->hasName() && st->getNumElements() == 0;
 }
 
-static llvm::Function *normalizeKernelReturnToVoid(llvm::Function *F) {
-  if (!F || F->isDeclaration())
+llvm::Function *normalizeKernelReturnToVoid(llvm::Function *F) {
+  if (!F || F->isDeclaration() || !F->hasFnAttribute("kernel") ||
+      F->getReturnType()->isVoidTy() || !isEmptyStructType(F->getReturnType()))
     return F;
-  if (!F->hasFnAttribute("kernel"))
-    return F;
-  if (F->getReturnType()->isVoidTy()) {
-    return F;
-  }
-  if (!isEmptyStructType(F->getReturnType())) {
-    return F;
-  }
 
   auto *M = F->getParent();
   auto &C = M->getContext();
@@ -724,8 +717,8 @@ static llvm::Function *normalizeKernelReturnToVoid(llvm::Function *F) {
   for (auto *argTy : oldTy->params())
     argTys.push_back(argTy);
 
-  auto *newTy = llvm::FunctionType::get(llvm::Type::getVoidTy(C), argTys,
-                                        oldTy->isVarArg());
+  auto *newTy =
+      llvm::FunctionType::get(llvm::Type::getVoidTy(C), argTys, oldTy->isVarArg());
   auto *G = llvm::Function::Create(newTy, F->getLinkage(), F->getAddressSpace(), "");
   M->getFunctionList().insert(F->getIterator(), G);
   G->takeName(F);
@@ -963,7 +956,7 @@ void applyGPUTransformations(llvm::Module *M, const std::string &ptxFilename) {
   llvm::NamedMDNode *nvvmAnno = clone->getOrInsertNamedMetadata("nvvm.annotations");
   std::vector<llvm::Function *> kernelCandidates;
   std::vector<llvm::GlobalValue *> kernels;
-  
+
   for (auto &F : *clone) {
     if (!F.hasFnAttribute("kernel"))
       continue;

--- a/codon/parser/visitors/typecheck/infer.cpp
+++ b/codon/parser/visitors/typecheck/infer.cpp
@@ -23,6 +23,10 @@ namespace codon::ast {
 
 using namespace types;
 
+namespace {
+const std::string GPU_KERNEL_ATTR = getMangledFunc("std.internal.gpu", "kernel");
+}
+
 /// Unify types a (passed by reference) and b.
 /// Destructive operation as it modifies both a and b. If types cannot be unified, raise
 /// an error.
@@ -740,8 +744,17 @@ ir::Func *TypecheckVisitor::makeIRFunction(
     types.pop_back();
     names.pop_back();
   }
+
+  auto *fnAttrs = r->ast->getAttribute<ir::KeyValueAttribute>(Attr::FunctionAttributes);
+  const bool isGpuKernel = fnAttrs && fnAttrs->has(GPU_KERNEL_ATTR);
+
+  auto *retType = makeIRType(r->type->getRetType()->getClass());
+  if (isGpuKernel && extractClassType(r->type->getRetType())->is("NoneType")) {
+    retType = irm->getVoidType();
+  }
+
   auto irType = irm->unsafeGetFuncType(r->type->realizedName(),
-                                       makeIRType(r->type->getRetType()->getClass()),
+                                       retType,
                                        types, r->ast->hasAttribute(Attr::CVarArg));
   irType->setAstType(r->type->shared_from_this());
   fn->realize(irType, names);

--- a/codon/parser/visitors/typecheck/infer.cpp
+++ b/codon/parser/visitors/typecheck/infer.cpp
@@ -23,10 +23,6 @@ namespace codon::ast {
 
 using namespace types;
 
-namespace {
-const std::string GPU_KERNEL_ATTR = getMangledFunc("std.internal.gpu", "kernel");
-}
-
 /// Unify types a (passed by reference) and b.
 /// Destructive operation as it modifies both a and b. If types cannot be unified, raise
 /// an error.
@@ -744,17 +740,8 @@ ir::Func *TypecheckVisitor::makeIRFunction(
     types.pop_back();
     names.pop_back();
   }
-
-  auto *fnAttrs = r->ast->getAttribute<ir::KeyValueAttribute>(Attr::FunctionAttributes);
-  const bool isGpuKernel = fnAttrs && fnAttrs->has(GPU_KERNEL_ATTR);
-
-  auto *retType = makeIRType(r->type->getRetType()->getClass());
-  if (isGpuKernel && extractClassType(r->type->getRetType())->is("NoneType")) {
-    retType = irm->getVoidType();
-  }
-
   auto irType = irm->unsafeGetFuncType(r->type->realizedName(),
-                                       retType,
+                                       makeIRType(r->type->getRetType()->getClass()),
                                        types, r->ast->hasAttribute(Attr::CVarArg));
   irType->setAstType(r->type->shared_from_this());
   fn->realize(irType, names);


### PR DESCRIPTION
Fixes #770

## Changes
- detect NVPTX kernel entry functions during lowering
- emit an explicit `void` return type for final kernel entry functions
- preserve existing higher-level semantics before final kernel lowering

## Validation
- verified that NVPTX kernel entry functions are now emitted with explicit `void` return types
- verified that the resulting kernels still compile and execute successfully

## Observed IR 
```
define dso_local void @hello_0_0_std_internal_types_array_List_0_int__std_internal_types_array_List_0_int__std_internal_types_array_List_0_int__(ptr nocapture readonly %0, ptr nocapture readonly %1, ptr nocapture readonly %2) local_unnamed_addr #1 {
...
  ret void
}
...

```