### PR TITLE
[Test] Speed up unit test execution with gtest_parallel

### DIFF
--- a/.github/build-linux/test.sh
+++ b/.github/build-linux/test.sh
@@ -22,6 +22,11 @@ export CODON_PYTHON=$(python ${WORKSPACE}/test/python/find-python-library.py)
 export PYTHONPATH=${WORKSPACE}/test/python
 export CODON_DIR=$(pwd)/codon-deploy-${ARCH}
 
+GTEST_PARALLEL="${WORKSPACE}/gtest-parallel/gtest-parallel"
+if [ ! -f "${GTEST_PARALLEL}" ]; then
+  git submodule update --init --recursive
+fi
+
 echo "=> Unit tests..."
 mkdir -p build  # needed for some tests that write into this directory
 if [ "${ARCH}" = "darwin-x86_64" ]; then
@@ -29,10 +34,10 @@ if [ "${ARCH}" = "darwin-x86_64" ]; then
   # (macOS 14 Intel runners are not free).
   # arithmetic.codon fails in debug mode on x86 due to float16 (TODO: why?)
   export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
-  time build-${ARCH}/codon_test --gtest_filter="-*numpy*:*core_arithmetic_codon_debug*"
+  time "${GTEST_PARALLEL}" build-${ARCH}/codon_test --gtest_filter="-*numpy*:*core_arithmetic_codon_debug*"
   # :*python*:*core_arithmetic*:*stdlib_random_test*"
 else
-  time build-${ARCH}/codon_test
+  time "${GTEST_PARALLEL}" build-${ARCH}/codon_test
 fi
 
 echo "=> Standalone test..."

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "gtest-parallel"]
+	path = gtest-parallel
+	url = https://github.com/google/gtest-parallel.git

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -314,8 +314,16 @@ public:
       GC_atfork_parent();
       int status = -1;
       close(out_pipe[1]);
+
+      buf.clear();
+      char temp_buf[4096];
+      ssize_t n;
+      while ((n = read(out_pipe[0], temp_buf, sizeof(temp_buf))) > 0) {
+        buf.insert(buf.end(), temp_buf, temp_buf + n);
+      }
+      buf.push_back('\0');
+
       assert(waitpid(pid, &status, 0) == pid);
-      read(out_pipe[0], buf.data(), buf.size() - 1);
       close(out_pipe[0]);
       return status;
     }


### PR DESCRIPTION
This patch integrates **gtest-parallel** into the project's test infrastructure to parallelize the execution of Google Test-based unit tests. It significantly reduces total test runtime by leveraging multi-core CPUs while fully preserving test correctness, isolation, and output behavior.