### PR TITLE
Bind `with ... as` targets to `__enter__()` return values

### DIFF
--- a/codon/parser/visitors/typecheck/error.cpp
+++ b/codon/parser/visitors/typecheck/error.cpp
@@ -224,25 +224,33 @@ void TypecheckVisitor::visit(WithStmt *stmt) {
 
   std::vector<Stmt *> content;
   for (auto i = stmt->items.size(); i-- > 0;) {
-    std::string var = stmt->vars[i].empty() ? getTemporaryVar("with") : stmt->vars[i];
-    auto as = N<AssignStmt>(N<IdExpr>(var), (*stmt)[i], nullptr,
-                            (*stmt)[i]->hasAttribute(Attr::ExprDominated)
-                                ? AssignStmt::UpdateMode::Update
-                                : AssignStmt::UpdateMode::Assign);
+    std::string manager = getTemporaryVar("with");
+    std::string var = stmt->vars[i];
+    auto managerAssign = N<AssignStmt>(N<IdExpr>(manager), (*stmt)[i], nullptr,
+                                       AssignStmt::UpdateMode::Assign);
 
     Expr *enter =
-        N<CallExpr>(N<DotExpr>(N<IdExpr>(var), isAsync ? "__aenter__" : "__enter__"));
+        N<CallExpr>(N<DotExpr>(N<IdExpr>(manager), isAsync ? "__aenter__" : "__enter__"));
     Expr *exit =
-        N<CallExpr>(N<DotExpr>(N<IdExpr>(var), isAsync ? "__aexit__" : "__exit__"));
+        N<CallExpr>(N<DotExpr>(N<IdExpr>(manager), isAsync ? "__aexit__" : "__exit__"));
     if (isAsync) {
       enter = N<AwaitExpr>(enter);
       exit = N<AwaitExpr>(exit);
     }
-    content = std::vector<Stmt *>{
-        as, N<ExprStmt>(enter),
+    std::vector<Stmt *> wrapped{managerAssign};
+    if (var.empty()) {
+      wrapped.push_back(N<ExprStmt>(enter));
+    } else {
+      wrapped.push_back(N<AssignStmt>(
+          N<IdExpr>(var), enter, nullptr,
+          (*stmt)[i]->hasAttribute(Attr::ExprDominated) ? AssignStmt::UpdateMode::Update
+                                                        : AssignStmt::UpdateMode::Assign));
+    }
+    wrapped.push_back(
         N<TryStmt>(!content.empty() ? N<SuiteStmt>(content) : clone(stmt->getSuite()),
                    std::vector<ExceptStmt *>{}, nullptr,
-                   N<SuiteStmt>(N<ExprStmt>(exit)))};
+                   N<SuiteStmt>(N<ExprStmt>(exit))));
+    content = std::move(wrapped);
   }
   resultStmt = transform(N<SuiteStmt>(content));
 }


### PR DESCRIPTION
## Limitation of this PR
This PR addresses only the first item of #787 : binding the result of `__enter__()` to the `as` target.

## Current state in pseudo code
The below code interpreted differently in each codon and python:
```python
with Manager() as pair:
	body
```

### In Codon
 Lowering current `with syntax in Codon` behaves conceptually like this:
```python
# assign Class Instance
pair = Manager()
# Only calls _enter_ method
pair.__enter__()
try:
    ...
finally:
    pair.__exit__()
```
In Codon, `pair` refers to the `Manager Class instance` in Codon, and the return value of `__enter__()` is discarded.

### In Python

In a While, `with syntax in Python` behaves like below pseudo code:
```python
# first  assign temporal Class instance
temp = Manager()
# assigns class methods
enter = temp.__enter__
exit = temp.__exit__
# Binding “pair” identifier with return value of enter method.
pair = enter()

try:
    ...
except:
    ...
finally:
    pair.__exit__()
```
https://docs.python.org/3/reference/compound_stmts.html#the-with-statement 
In Python, `pair` refers to the return value of `__enter__()` .

## What this PR fixes
Conceptually, lowering changes to:

```python
_mgr = Manager()
var = _mgr.__enter__()
try:
    body
finally:
    _mgr.__exit__()
```
