### PR TITLE
Fix: Separate CPU and GPU LLVM optimization pipelines before GPU lowering

### DIFF
--- a/codon/cir/llvm/gpu.cpp
+++ b/codon/cir/llvm/gpu.cpp
@@ -945,8 +945,7 @@ void patchPTXVar(llvm::Module *M, llvm::GlobalValue *ptxVar,
 }
 } // namespace
 
-void applyGPUTransformations(llvm::Module *M, const std::string &ptxFilename) {
-  llvm::LLVMContext &context = M->getContext();
+std::unique_ptr<llvm::Module> prepareGPUmodule(llvm::Module *M){
   std::unique_ptr<llvm::Module> clone = llvm::CloneModule(*M);
   clone->setTargetTriple(llvm::Triple::normalize(GPU_TRIPLE));
   clone->setDataLayout(GPU_DL);
@@ -954,7 +953,11 @@ void applyGPUTransformations(llvm::Module *M, const std::string &ptxFilename) {
     clone->addModuleFlag(llvm::Module::ModFlagBehavior::Override, "nvvm-reflect-ftz",
                          1);
   }
+  return clone;
+}
 
+void applyGPUTransformations(llvm::Module *M, std::unique_ptr<llvm::Module> clone, const std::string &ptxFilename) {
+    llvm::LLVMContext &context = M->getContext();
   llvm::NamedMDNode *nvvmAnno = clone->getOrInsertNamedMetadata("nvvm.annotations");
   std::vector<llvm::Function *> kernelCandidates;
   std::vector<llvm::GlobalValue *> kernels;

--- a/codon/cir/llvm/gpu.cpp
+++ b/codon/cir/llvm/gpu.cpp
@@ -945,7 +945,7 @@ void patchPTXVar(llvm::Module *M, llvm::GlobalValue *ptxVar,
 }
 } // namespace
 
-std::unique_ptr<llvm::Module> prepareGPUmodule(llvm::Module *M){
+std::unique_ptr<llvm::Module> prepareGPUmodule(llvm::Module *M) {
   std::unique_ptr<llvm::Module> clone = llvm::CloneModule(*M);
   clone->setTargetTriple(llvm::Triple::normalize(GPU_TRIPLE));
   clone->setDataLayout(GPU_DL);
@@ -956,8 +956,9 @@ std::unique_ptr<llvm::Module> prepareGPUmodule(llvm::Module *M){
   return clone;
 }
 
-void applyGPUTransformations(llvm::Module *M, std::unique_ptr<llvm::Module> clone, const std::string &ptxFilename) {
-    llvm::LLVMContext &context = M->getContext();
+void applyGPUTransformations(llvm::Module *M, std::unique_ptr<llvm::Module> clone,
+                             const std::string &ptxFilename) {
+  llvm::LLVMContext &context = M->getContext();
   llvm::NamedMDNode *nvvmAnno = clone->getOrInsertNamedMetadata("nvvm.annotations");
   std::vector<llvm::Function *> kernelCandidates;
   std::vector<llvm::GlobalValue *> kernels;

--- a/codon/cir/llvm/gpu.h
+++ b/codon/cir/llvm/gpu.h
@@ -15,7 +15,9 @@ namespace ir {
 /// annotation)
 /// @param ptxFilename Filename for output PTX code; empty to use filename based on
 /// module
-void applyGPUTransformations(llvm::Module *module, const std::string &ptxFilename = "");
+
+std::unique_ptr<llvm::Module> prepareGPUmodule(llvm::Module *module);
+void applyGPUTransformations(llvm::Module *module, std::unique_ptr<llvm::Module> clone, const std::string &ptxFilename = "");
 
 } // namespace ir
 } // namespace codon

--- a/codon/cir/llvm/gpu.h
+++ b/codon/cir/llvm/gpu.h
@@ -9,15 +9,21 @@
 namespace codon {
 namespace ir {
 
-/// Applies GPU-specific transformations and generates PTX
-/// code from kernel functions in the given LLVM module.
-/// @param module LLVM module containing GPU kernel functions (marked with "kernel"
-/// annotation)
-/// @param ptxFilename Filename for output PTX code; empty to use filename based on
-/// module
+/// Applies GPU-specific transformations to the prepared GPU module, generates
+/// PTX for kernel functions, and patches the original module accordingly.
+/// @param module Original LLVM module to patch with generated GPU artifacts.
+/// @param clone GPU-targeted module produced by prepareGPUmodule(); ownership is
+/// consumed.
+/// @param ptxFilename Filename for output PTX code; empty to derive it from the module.
 
+void applyGPUTransformations(llvm::Module *module, std::unique_ptr<llvm::Module> clone,
+                             const std::string &ptxFilename = "");
+
+/// Creates a GPU-targeted clone of the given LLVM module.
+/// The cloned module is configured with the GPU target triple and data layout
+/// so it can go through the GPU-specific optimization pipeline.
+/// @param module LLVM module containing both host code and GPU kernel functions.
+/// @return A cloned module configured for GPU lowering.
 std::unique_ptr<llvm::Module> prepareGPUmodule(llvm::Module *module);
-void applyGPUTransformations(llvm::Module *module, std::unique_ptr<llvm::Module> clone, const std::string &ptxFilename = "");
-
 } // namespace ir
 } // namespace codon

--- a/codon/cir/llvm/optimize.cpp
+++ b/codon/cir/llvm/optimize.cpp
@@ -995,28 +995,9 @@ llvm::cl::opt<bool>
                   llvm::cl::desc("Disable architecture-specific optimizations"),
                   llvm::cl::init(false));
 
-void runLLVMOptimizationPasses(llvm::Module *module, bool debug, bool jit,
-                               PluginManager *plugins) {
-  applyDebugTransformations(module, debug, jit);
-  applyFastMathTransformations(module);
-
-  llvm::LoopAnalysisManager lam;
-  llvm::FunctionAnalysisManager fam;
-  llvm::CGSCCAnalysisManager cgam;
-  llvm::ModuleAnalysisManager mam;
-  auto machine = getTargetMachine(module, /*setFunctionAttributes=*/true);
-  llvm::PassBuilder pb(machine.get());
-
-  llvm::Triple moduleTriple(module->getTargetTriple());
-  llvm::TargetLibraryInfoImpl tlii(moduleTriple);
-  fam.registerPass([&] { return llvm::TargetLibraryAnalysis(tlii); });
-
-  pb.registerModuleAnalyses(mam);
-  pb.registerCGSCCAnalyses(cgam);
-  pb.registerFunctionAnalyses(fam);
-  pb.registerLoopAnalyses(lam);
-  pb.crossRegisterProxies(lam, fam, cgam, mam);
-
+void registerCodonLLVMOptimizationPasses(llvm::PassBuilder &pb, bool debug,
+                                         PluginManager *plugins, bool includeNative,
+                                         bool includePlugins) {
   pb.registerLateLoopOptimizationsEPCallback(
       [&](llvm::LoopPassManager &pm, llvm::OptimizationLevel opt) {
         if (opt.isOptimizingForSpeed())
@@ -1035,14 +1016,43 @@ void runLLVMOptimizationPasses(llvm::Module *module, bool debug, bool jit,
         }
       });
 
-  if (!DisableNative)
+  if (!DisableNative && includeNative)
     addNativeLLVMPasses(&pb);
 
-  if (plugins) {
+  if (includePlugins && plugins) {
     for (auto *plugin : *plugins) {
       plugin->dsl->addLLVMPasses(&pb, debug);
     }
   }
+}
+
+void runLLVMOptimizationPasses(llvm::Module *module, bool debug, bool jit,
+                               PluginManager *plugins, bool includeNative,
+                               bool includePlugins) {
+  applyDebugTransformations(module, debug, jit);
+  applyFastMathTransformations(module);
+
+  llvm::LoopAnalysisManager lam;
+  llvm::FunctionAnalysisManager fam;
+  llvm::CGSCCAnalysisManager cgam;
+  llvm::ModuleAnalysisManager mam;
+  auto machine =
+      includeNative ? getTargetMachine(module, /*setFunctionAttributes=*/true)
+                    : std::unique_ptr<llvm::TargetMachine>();
+  llvm::PassBuilder pb(machine.get());
+
+  llvm::Triple moduleTriple(module->getTargetTriple());
+  llvm::TargetLibraryInfoImpl tlii(moduleTriple);
+  fam.registerPass([&] { return llvm::TargetLibraryAnalysis(tlii); });
+
+  pb.registerModuleAnalyses(mam);
+  pb.registerCGSCCAnalyses(cgam);
+  pb.registerFunctionAnalyses(fam);
+  pb.registerLoopAnalyses(lam);
+  pb.crossRegisterProxies(lam, fam, cgam, mam);
+
+  registerCodonLLVMOptimizationPasses(pb, debug, plugins, includeNative,
+                                      includePlugins);
 
   if (debug) {
     llvm::ModulePassManager mpm =
@@ -1081,11 +1091,17 @@ void optimize(llvm::Module *module, bool debug, bool jit, PluginManager *plugins
   }
   {
     TIME("llvm/opt1");
-    runLLVMOptimizationPasses(module, debug, jit, plugins);
+    runLLVMOptimizationPasses(module, debug, jit, plugins, true, true);
   }
   if (!debug) {
     TIME("llvm/opt2");
-    runLLVMOptimizationPasses(module, debug, jit, plugins);
+    runLLVMOptimizationPasses(module, debug, jit, plugins, true, true);
+  }
+  {
+    TIME("llvm/gpuopt");
+    runLLVMOptimizationPasses(GPUmodule.get(), debug, jit, plugins,
+                              /*includeNative=*/false,
+                              /*includePlugins=*/false);
   }
   {
     TIME("llvm/gpu");

--- a/codon/cir/llvm/optimize.cpp
+++ b/codon/cir/llvm/optimize.cpp
@@ -1098,7 +1098,13 @@ void optimize(llvm::Module *module, bool debug, bool jit, PluginManager *plugins
     runLLVMOptimizationPasses(module, debug, jit, plugins, true, true);
   }
   {
-    TIME("llvm/gpuopt");
+    TIME("llvm/gpuopt1");
+    runLLVMOptimizationPasses(GPUmodule.get(), debug, jit, plugins,
+                              /*includeNative=*/false,
+                              /*includePlugins=*/false);
+  }
+  {
+    TIME("llvm/gpuopt2");
     runLLVMOptimizationPasses(GPUmodule.get(), debug, jit, plugins,
                               /*includeNative=*/false,
                               /*includePlugins=*/false);

--- a/codon/cir/llvm/optimize.cpp
+++ b/codon/cir/llvm/optimize.cpp
@@ -1036,9 +1036,9 @@ void runLLVMOptimizationPasses(llvm::Module *module, bool debug, bool jit,
   llvm::FunctionAnalysisManager fam;
   llvm::CGSCCAnalysisManager cgam;
   llvm::ModuleAnalysisManager mam;
-  auto machine =
-      includeNative ? getTargetMachine(module, /*setFunctionAttributes=*/true)
-                    : std::unique_ptr<llvm::TargetMachine>();
+  auto machine = includeNative
+                     ? getTargetMachine(module, /*setFunctionAttributes=*/true)
+                     : std::unique_ptr<llvm::TargetMachine>();
   llvm::PassBuilder pb(machine.get());
 
   llvm::Triple moduleTriple(module->getTargetTriple());
@@ -1091,11 +1091,15 @@ void optimize(llvm::Module *module, bool debug, bool jit, PluginManager *plugins
   }
   {
     TIME("llvm/opt1");
-    runLLVMOptimizationPasses(module, debug, jit, plugins, true, true);
+    runLLVMOptimizationPasses(module, debug, jit, plugins,
+                              /*includeNative=*/true,
+                              /*includePlugins=*/true);
   }
   if (!debug) {
     TIME("llvm/opt2");
-    runLLVMOptimizationPasses(module, debug, jit, plugins, true, true);
+    runLLVMOptimizationPasses(module, debug, jit, plugins,
+                              /*includeNative=*/true,
+                              /*includePlugins=*/true);
   }
   {
     TIME("llvm/gpuopt1");

--- a/codon/cir/llvm/optimize.cpp
+++ b/codon/cir/llvm/optimize.cpp
@@ -1074,6 +1074,11 @@ void verify(llvm::Module *module) {
 
 void optimize(llvm::Module *module, bool debug, bool jit, PluginManager *plugins) {
   verify(module);
+  std::unique_ptr<llvm::Module> GPUmodule;
+  {
+    TIME("preparing/gpu");
+    GPUmodule = prepareGPUmodule(module);
+  }
   {
     TIME("llvm/opt1");
     runLLVMOptimizationPasses(module, debug, jit, plugins);
@@ -1084,7 +1089,7 @@ void optimize(llvm::Module *module, bool debug, bool jit, PluginManager *plugins
   }
   {
     TIME("llvm/gpu");
-    applyGPUTransformations(module);
+    applyGPUTransformations(module, std::move(GPUmodule));
   }
   verify(module);
 }


### PR DESCRIPTION
fixes #792 

## What this PR Fixes
This PR changes the pipeline structure so that CPU and GPU modules are separated before their respective optimization flows are applied.

## 2-pass Optimization
Like CPU Module, also GPU module introduced 2-pass Optimzation.

But Not only for performance,

### When Only 1-pass Optimzation is occured,
```

.version 4.2
.target sm_30
.address_size 64

	// .globl	std_numpy_indexing__getset_0_0_std_numpy_ndarray_ndarray_0_float32_1__Tuple_std_internal_types_slice_Slice_0_int_int_int___std_numpy_ndarray_ndarray_0_float32_1__float32__3860
.extern .func  (.param .b64 func_retval0) malloc
(
	.param .b64 malloc_param_0
)
;
.visible .func std_numpy_util_multirange_0_0_Tuple_int___3272_resume
(
	.param .b64 std_numpy_util_multirange_0_0_Tuple_int___3272_resume_param_0
)
;
.extern .global .align 1 .b8 _str_209[2];
.extern .global .align 1 .b8 _str_210[2];
.extern .global .align 1 .b8 _str_211[2];
.extern .global .align 1 .b8 _str_212[2];
.extern .global .align 1 .b8 _str_223[2];
.extern .global .align 1 .b8 _str_224[2];
.extern .global .align 1 .b8 _str_225[2];
.extern .global .align 1 .b8 _str_226[2];
.extern .global .align 1 .b8 _str_272[2];
.extern .global .align 1 .b8 _str_273[2];
.extern .global .align 1 .b8 _str_274[2];
.extern .global .align 1 .b8 _str_275[2];
.extern .global .align 1 .b8 _str_276[2];
.extern .global .align 1 .b8 _str_277[2];
.extern .global .align 1 .b8 _str_278[2];
.extern .global .align 1 .b8 _str_279[2];
.extern .global .align 1 .b8 _str_280[2];
.extern .global .align 1 .b8 _str_313[2];
.extern .global .align 1 .b8 _str_318[2];
...

```

Un-inlined GV are retained, these seems to occur invalid PTX.

### 2-pass

```
.version 4.2
.target sm_30
.address_size 64

	// .globl	exp_kernel_naver_02_0_0_std_numpy_ndarray_ndarray_0_float32_1__std_numpy_ndarray_ndarray_0_float32_1__
.extern .func  (.param .b64 func_retval0) malloc
(
	.param .b64 malloc_param_0
)
;
...
```

Seems 2-pass opt inlines GV, And this case works correctly.

## ApplyGPUTransformation
`ApplyGPUTransformation` does lots of jobs. 

It clones module, separate CPU and GPU module, run NVPTX passes, cleanup CPU module, and Patches.

In only one Function, it contains these jobs, so to optimize each module, dividing logic of this function was inevitable I think. 