### PR TITLE
NumPy fusion optimization inlining fix

### DIFF
--- a/codon/cir/transform/numpy/expr.cpp
+++ b/codon/cir/transform/numpy/expr.cpp
@@ -601,6 +601,12 @@ Var *NumPyExpr::codegenSequentialEval(CodegenContext &C) {
   auto &vars = C.vars;
   auto &T = C.T;
 
+  auto freeArray = [&](Var *arr) {
+    auto *freeFunc = M->getOrRealizeFunc("_free", {arr->getType()}, {}, FUSION_MODULE);
+    seqassertn(freeFunc, "free func not found");
+    return util::call(freeFunc, {M->Nr<VarValue>(arr)});
+  };
+
   if (isLeaf()) {
     auto it = vars.find(this);
     seqassertn(it != vars.end(),
@@ -613,13 +619,23 @@ Var *NumPyExpr::codegenSequentialEval(CodegenContext &C) {
   Var *like = nullptr;
   Value *outShapeVal = nullptr;
 
+  bool lfreeable = lhs && lhs->type.isArray() && (lhs->freeable || !lhs->isLeaf());
+  bool rfreeable = rhs && rhs->type.isArray() && (rhs->freeable || !rhs->isLeaf());
+  bool ltmp = lfreeable && lhs->type.dtype == type.dtype && lhs->type.ndim == type.ndim;
+  bool rtmp = rfreeable && rhs->type.dtype == type.dtype && rhs->type.ndim == type.ndim;
+
   if (rv) {
     // Can't do anything special with matmul here...
     if (op == NP_OP_MATMUL) {
       auto *matmul = M->getOrRealizeFunc("_matmul", {lv->getType(), rv->getType()}, {},
                                          FUSION_MODULE);
-      return util::makeVar(
+      auto *ret = util::makeVar(
           util::call(matmul, {M->Nr<VarValue>(lv), M->Nr<VarValue>(rv)}), series, func);
+      if (lfreeable)
+        series->push_back(freeArray(lv));
+      if (rfreeable)
+        series->push_back(freeArray(rv));
+      return ret;
     }
 
     auto *lshape = M->getOrRealizeFunc("_shape", {lv->getType()}, {}, FUSION_MODULE);
@@ -642,11 +658,6 @@ Var *NumPyExpr::codegenSequentialEval(CodegenContext &C) {
 
   auto *outShape = util::makeVar(outShapeVal, series, func);
   Var *result = nullptr;
-
-  bool lfreeable = lhs && lhs->type.isArray() && (lhs->freeable || !lhs->isLeaf());
-  bool rfreeable = rhs && rhs->type.isArray() && (rhs->freeable || !rhs->isLeaf());
-  bool ltmp = lfreeable && lhs->type.dtype == type.dtype && lhs->type.ndim == type.ndim;
-  bool rtmp = rfreeable && rhs->type.dtype == type.dtype && rhs->type.ndim == type.ndim;
 
   auto *t = type.getIRBaseType(T);
   auto newArray = [&]() {
@@ -866,12 +877,6 @@ Var *NumPyExpr::codegenSequentialEval(CodegenContext &C) {
     series->push_back(
         util::call(loopFunc, {arraysTuple, M->Nr<VarValue>(scalarFunc), extraTuple}));
   }
-
-  auto freeArray = [&](Var *arr) {
-    auto *freeFunc = M->getOrRealizeFunc("_free", {arr->getType()}, {}, FUSION_MODULE);
-    seqassertn(freeFunc, "free func not found");
-    return util::call(freeFunc, {M->Nr<VarValue>(arr)});
-  };
 
   seqassertn(!(freeLeftStatic && lcond), "unexpected free conditions for left arg");
   seqassertn(!(freeRightStatic && rcond), "unexpected free conditions for right arg");

--- a/codon/cir/transform/numpy/numpy.cpp
+++ b/codon/cir/transform/numpy/numpy.cpp
@@ -700,6 +700,12 @@ Var *optimizeHelper(NumPyOptimizationUnit &unit, NumPyExpr *expr, CodegenContext
   auto *M = unit.value->getModule();
   auto *series = C.series;
 
+  auto freeArray = [&](Var *arr) {
+    auto *freeFunc = M->getOrRealizeFunc("_free", {arr->getType()}, {}, FUSION_MODULE);
+    seqassertn(freeFunc, "free func not found");
+    return util::call(freeFunc, {M->Nr<VarValue>(arr)});
+  };
+
   // Remove some operations that cannot be done element-wise easily by optimizing them
   // separately, recursively.
   expr->apply([&](NumPyExpr &e) {
@@ -728,6 +734,15 @@ Var *optimizeHelper(NumPyOptimizationUnit &unit, NumPyExpr *expr, CodegenContext
       auto *var = util::makeVar(
           util::call(matmulFunc, {M->Nr<VarValue>(lv), M->Nr<VarValue>(rv)}), C.series,
           C.func);
+
+      bool lfreeable = e.lhs->type.isArray() && (e.lhs->freeable || !e.lhs->isLeaf());
+      bool rfreeable = e.rhs->type.isArray() && (e.rhs->freeable || !e.rhs->isLeaf());
+
+      if (lfreeable)
+        series->push_back(freeArray(lv));
+      if (rfreeable)
+        series->push_back(freeArray(rv));
+
       C.vars[&e] = var;
       NumPyExpr replacement(e.type, M->Nr<VarValue>(var));
       replacement.freeable = true;

--- a/stdlib/numpy/fusion.codon
+++ b/stdlib/numpy/fusion.codon
@@ -54,9 +54,11 @@ def _contig_match(arrs):
 def _ptrset(p: Ptr[T], x: T, T: type):
     p[0] = x
 
+@inline
 def _loop_alloc(arrays, func, extra, dtype: type):
     return ndarray._loop(arrays, func, alloc=Tuple[dtype], extra=extra)[0]
 
+@inline
 def _loop_basic(arrays, func, extra):
     ndarray._loop(arrays, func, extra=extra)
 

--- a/stdlib/numpy/ndarray.codon
+++ b/stdlib/numpy/ndarray.codon
@@ -619,6 +619,7 @@ class ndarray[dtype, ndim: Literal[int]]:
 
         return ndarray(shape, self._data, fcontig=(order == 'F'))
 
+    @inline
     def _loop(arrays, func, broadcast: Literal[str] = 'all',
               check: Literal[bool] = True, alloc: type = type(()),
               optimize_order: Literal[bool] = True, extra = None):


### PR DESCRIPTION
Previously, some of the internal `ndarray._loop()` calls would not be inlined when generating fused code during NumPy optimization, causing poor performance. This change forces inlining. Additionally, it includes a change to free temporary arrays after matrix multiplication in the generated fused code.