### PR TITLE
Zero memory when removing from collections

### DIFF
--- a/stdlib/collections.codon
+++ b/stdlib/collections.codon
@@ -86,17 +86,24 @@ class deque:
     def popleft(self) -> T:
         self._check_not_empty()
         res = self._arr[self._head]
+        if not T.__atomic__:
+            str.memset((self._arr.ptr + self._head).as_byte(), byte(0), T.__elemsize__)
         self._head = (self._head + 1) & (len(self._arr) - 1)
         return res
 
     def pop(self) -> T:
         self._check_not_empty()
         self._tail = (self._tail - 1) & (len(self._arr) - 1)
-        return self._arr[self._tail]
+        res = self._arr[self._tail]
+        if not T.__atomic__:
+            str.memset((self._arr.ptr + self._tail).as_byte(), byte(0), T.__elemsize__)
+        return res
 
     def clear(self):
         self._head = 0
         self._tail = 0
+        if not T.__atomic__:
+            str.memset(self._arr.ptr.as_byte(), byte(0), len(self._arr) * T.__elemsize__)
 
     def __iter__(self) -> Generator[T]:
         i = self._head

--- a/stdlib/internal/types/collections/dict.codon
+++ b/stdlib/internal/types/collections/dict.codon
@@ -255,6 +255,10 @@ class Dict:
             while i < n:
                 self._flags[i] = u32(0xAAAAAAAA)
                 i += 1
+            if not K.__atomic__:
+                str.memset(self._keys.as_byte(), byte(0), self._n_buckets * gc.sizeof(K))
+            if not V.__atomic__:
+                str.memset(self._vals.as_byte(), byte(0), self._n_buckets * gc.sizeof(V))
             self._size = 0
             self._n_occupied = 0
 
@@ -417,6 +421,10 @@ class Dict:
     def _kh_del(self, x: int):
         if x != self._n_buckets and not khash.__ac_iseither(self._flags, x):
             khash.__ac_set_isdel_true(self._flags, x)
+            if not K.__atomic__:
+                str.memset((self._keys + x).as_byte(), byte(0), gc.sizeof(K))
+            if not V.__atomic__:
+                str.memset((self._vals + x).as_byte(), byte(0), gc.sizeof(V))
             self._size -= 1
 
     def _kh_begin(self) -> int:

--- a/stdlib/internal/types/collections/list.codon
+++ b/stdlib/internal/types/collections/list.codon
@@ -63,14 +63,19 @@ class List:
         self._idx_check(idx, "list assignment index out of range")
         self._set(idx, val)
 
-    def __delitem__(self, idx: int):
-        if idx < 0:
-            idx += self.__len__()
-        self._idx_check(idx, "list assignment index out of range")
+    def _delete(self, idx: int):
         while idx < self.len - 1:
             self._set(idx, self._get(idx + 1))
             idx += 1
         self.len -= 1
+        if not T.__atomic__:
+            str.memset((self.arr.ptr + self.len).as_byte(), byte(0), gc.sizeof(T))
+
+    def __delitem__(self, idx: int):
+        if idx < 0:
+            idx += self.__len__()
+        self._idx_check(idx, "list assignment index out of range")
+        self._delete(idx)
 
     def __eq__(self, other: List[T]) -> bool:
         if self.__len__() != other.__len__():
@@ -115,12 +120,7 @@ class List:
             if (step < 0 and start < stop) or (step > 0 and start > stop):
                 stop = start
 
-            seq: Optional[List[T]] = None
-            if other.__raw__() == self.__raw__():
-                seq = other.__copy__()
-            else:
-                seq = other
-
+            seq = other.__copy__() if (other is self) else other
             seq_len = seq.__len__()
             if seq_len != length:
                 raise ValueError(
@@ -176,7 +176,9 @@ class List:
                     )
 
                 self.len -= length
-                # self._resize(self.__len__())
+                if not T.__atomic__:
+                    str.memset((self.arr.ptr + self.len).as_byte(),
+                               byte(0), length * gc.sizeof(T))
 
     def __contains__(self, x: T) -> bool:
         for a in self:
@@ -322,19 +324,21 @@ class List:
             idx += self.__len__()
         self._idx_check(idx, "pop index out of range")
         x = self._get(idx)
-        del self[idx]
+        self._delete(idx)
         return x
 
     def remove(self, x: T) -> bool:
-        i = 0
-        for a in self:
-            if a == x:
-                del self[i]
+        p = self.arr.ptr
+        for i in range(self.len):
+            if p[i] == x:
+                self._delete(i)
                 return True
-            i += 1
         return False
 
     def clear(self):
+        if not T.__atomic__:
+            str.memset(self.arr.ptr.as_byte(),
+                       byte(0), self.len * gc.sizeof(T))
         self.len = 0
 
     def index(self, x: T) -> int:
@@ -413,7 +417,6 @@ class List:
             ihigh = L
 
         norig = ihigh - ilow
-        assert norig >= 0
         d = n - norig
         if L + d == 0:
             a.clear()

--- a/stdlib/internal/types/collections/set.codon
+++ b/stdlib/internal/types/collections/set.codon
@@ -263,6 +263,8 @@ class Set:
             while i < n:
                 self._flags[i] = u32(0xAAAAAAAA)
                 i += 1
+            if not K.__atomic__:
+                str.memset(self._keys.as_byte(), byte(0), self._n_buckets * gc.sizeof(K))
             self._size = 0
             self._n_occupied = 0
 
@@ -412,6 +414,8 @@ class Set:
     def _kh_del(self, x: int):
         if x != self._n_buckets and not khash.__ac_iseither(self._flags, x):
             khash.__ac_set_isdel_true(self._flags, x)
+            if not K.__atomic__:
+                str.memset((self._keys + x).as_byte(), byte(0), gc.sizeof(K))
             self._size -= 1
 
     def _kh_begin(self) -> int:

--- a/test/core/containers.codon
+++ b/test/core/containers.codon
@@ -233,11 +233,11 @@ def test_list():
     assert l3 == [1, 3]
     assert list[int]().remove(0) == False
 
-    # l4 = [5, 1, 4, 2, 1, -10, 10, 100, -100]
-    # assert sorted(l4) == [-100, -10, 1, 1, 2, 4, 5, 10, 100]
-    #l4.sort()
-    #assert l4 == [-100, -10, 1, 1, 2, 4, 5, 10, 100]
-    #assert str(sorted(list[int]())) == "[]"
+    l4 = [5, 1, 4, 2, 1, -10, 10, 100, -100]
+    assert sorted(l4) == [-100, -10, 1, 1, 2, 4, 5, 10, 100]
+    l4.sort()
+    assert l4 == [-100, -10, 1, 1, 2, 4, 5, 10, 100]
+    assert str(sorted(list[int]())) == "[]"
 
     l5 = [11, 22, 33, 44]
     del l5[-1]
@@ -329,6 +329,116 @@ def test_list():
     assert b2 == ['a']
     assert b3 == [4.2]
     assert b4 == [2.4]
+
+    # item deletion on list of non-atomic type
+    # --- basic deletes ---
+    l9 = ["a", "b", "c", "d", "e"]
+    del l9[0]
+    assert l9 == ["b", "c", "d", "e"]
+
+    del l9[-1]
+    assert l9 == ["b", "c", "d"]
+
+    del l9[1]
+    assert l9 == ["b", "d"]
+
+    # delete entire list via slice
+    del l9[:]
+    assert l9 == []
+
+    # --- slice deletes ---
+    l9 = ["a", "b", "c", "d", "e", "f"]
+    del l9[1:4]
+    assert l9 == ["a", "e", "f"]
+
+    l9 = ["a", "b", "c", "d", "e", "f"]
+    del l9[::2]  # delete even indices
+    assert l9 == ["b", "d", "f"]
+
+    l9 = ["a", "b", "c", "d", "e", "f"]
+    del l9[1::2]  # delete odd indices
+    assert l9 == ["a", "c", "e"]
+
+    # negative step delete
+    l9 = ["a", "b", "c", "d", "e", "f"]
+    del l9[::-2]
+    assert l9 == ["a", "c", "e"]
+
+    # --- slice assignment (same length) ---
+    l9 = ["a", "b", "c", "d"]
+    l9[1:3] = ["x", "y"]
+    assert l9 == ["a", "x", "y", "d"]
+
+    # --- slice assignment (shrink) ---
+    l9 = ["a", "b", "c", "d", "e"]
+    l9[1:4] = ["x"]
+    assert l9 == ["a", "x", "e"]
+
+    # --- slice assignment (grow) ---
+    l9 = ["a", "b", "c"]
+    l9[1:2] = ["x", "y", "z"]
+    assert l9 == ["a", "x", "y", "z", "c"]
+
+    # --- extended slice assignment (step != 1, must match length) ---
+    l9 = ["a", "b", "c", "d", "e", "f"]
+    l9[::2] = ["x", "y", "z"]
+    assert l9 == ["x", "b", "y", "d", "z", "f"]
+
+    l9 = ["a", "b", "c", "d", "e", "f"]
+    l9[1::2] = ["u", "v", "w"]
+    assert l9 == ["a", "u", "c", "v", "e", "w"]
+
+    # --- extended slice assignment with negative step ---
+    l9 = ["a", "b", "c", "d", "e", "f"]
+    l9[::-2] = ["x", "y", "z"]
+    assert l9 == ["a", "z", "c", "y", "e", "x"]
+
+    # --- replace entire list via slice ---
+    l9 = ["a", "b", "c"]
+    l9[:] = ["x", "y"]
+    assert l9 == ["x", "y"]
+
+    # --- insert via empty slice ---
+    l9 = ["a", "b", "c"]
+    l9[1:1] = ["x", "y"]
+    assert l9 == ["a", "x", "y", "b", "c"]
+
+    # --- delete via assigning empty list ---
+    l9 = ["a", "b", "c", "d"]
+    l9[1:3] = []
+    assert l9 == ["a", "d"]
+
+    # --- clear() ---
+    l9 = ["a", "b", "c"]
+    l9.clear()
+    assert l9 == []
+
+    # --- interactions after clear ---
+    l9 = ["a", "b"]
+    l9.clear()
+    l9.append("x")
+    assert l9 == ["x"]
+
+    # --- edge cases ---
+    # deleting single-element slice
+    l9 = ["a", "b", "c"]
+    del l9[1:2]
+    assert l9 == ["a", "c"]
+
+    # assigning to empty list
+    l9 = []
+    l9[:] = ["a", "b"]
+    assert l9 == ["a", "b"]
+
+    # deleting with out-of-bounds slice (should be safe)
+    l9 = ["a", "b"]
+    del l9[5:10]
+    assert l9 == ["a", "b"]
+
+    # assigning empty extended slice (no-op but valid)
+    l9 = ["a", "b", "c"]
+    l9[5:10] = []
+    assert l9 == ["a", "b", "c"]
 test_list()
 
 @test
@@ -555,6 +665,35 @@ def test_set():
     except ValueError:
         pass
 
+    s1 = {'1', '2', '3', '999999'}
+    s2 = {'1', '2', '3', '999999'}
+    v = s1.pop()
+    assert v in s2
+    s2.remove(v)
+
+    v = s1.pop()
+    assert v in s2
+    s2.remove(v)
+
+    v = s1.pop()
+    assert v in s2
+    s2.remove(v)
+
+    v = s1.pop()
+    assert v in s2
+    s2.remove(v)
+
+    try:
+        s1.pop()
+        assert False
+    except ValueError:
+        pass
+
+    s1 = {'1', '2', '3', '999999'}
+    s1.clear()
+    s1.add('42')
+    assert repr(s1) == "{'42'}"
+
     assert repr({(1,2)}) == '{(1, 2)}'
     assert repr(Set[int]()) == 'set()'
 test_set()
@@ -599,6 +738,13 @@ def test_dict():
 
     assert repr({1: ['x']}) == "{1: ['x']}"
     assert repr(Dict[int,int]()) == '{}'
+
+    d5 = {'1': 'one', '2': 'two', '3': 'three'}
+    assert d5.pop('2') == 'two'
+    assert len(d5) == 2 and d5['1'] == 'one' and d5['3'] == 'three'
+    d5.clear()
+    d5['4'] = 'four'
+    assert repr(d5) == "{'4': 'four'}"
 test_dict()
 
 def slice_indices(slice, length):
@@ -842,6 +988,46 @@ def test_deque():
     for i in range(5):
         dq.append(i)
     assert str(dq) == 'deque([0, 1, 2, 3, 4])'
+
+    dq = deque[str]()
+    dq.append('1')
+    dq.append('2')
+    dq.append('3')
+    dq.appendleft('11')
+    dq.appendleft('22')
+    assert str(dq) == "deque(['22', '11', '1', '2', '3'])"
+    assert bool(dq) == True
+
+    # test cap increase:
+    dq.clear()
+    assert bool(dq) == False
+    for i in range(20):
+        dq.append(str(i))
+        dq.appendleft(str(i))
+    assert str(dq) == "deque(['19', '18', '17', '16', '15', '14', '13', '12', '11', '10', '9', '8', '7', '6', '5', '4', '3', '2', '1', '0', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19'])"
+    assert len(dq) == 40
+
+    for i in range(19):
+        dq.pop()
+        dq.popleft()
+    assert str(dq) == "deque(['0', '0'])"
+    for a in dq:
+        assert a == '0'
+
+    assert ('0' in dq) == True
+    assert ('1' in dq) == False
+    assert str(copy(dq)) == "deque(['0', '0'])"
+
+    # test maxlen:
+    dq = deque[str](5)
+    for i in range(100):
+        dq.append(str(i))
+    assert str(dq) == "deque(['95', '96', '97', '98', '99'])"
+
+    for i in range(5):
+        dq.append(str(i))
+    assert str(dq) == "deque(['0', '1', '2', '3', '4'])"
+
 test_deque()
 
 @test


### PR DESCRIPTION
This allows the GC to properly free objects when there are no actual references. Previously, these references would persist in memory even after removal from collections (lists/dicts/sets/etc.). This only applies to non-atomic types (i.e. types that contain pointers).