### PR TITLE
Implement int parsing natively

### DIFF
--- a/codon/parser/visitors/typecheck/basic.cpp
+++ b/codon/parser/visitors/typecheck/basic.cpp
@@ -101,7 +101,7 @@ Expr *TypecheckVisitor::transformInt(IntExpr *expr) {
   if (!expr->hasStoredValue()) {
     holder = N<StringExpr>(value);
     if (suffix.empty())
-      suffix = "i64";
+      E(Error::INT_RANGE, expr, value);
   } else {
     holder = N<IntExpr>(expr->getValue());
   }

--- a/codon/runtime/lib.cpp
+++ b/codon/runtime/lib.cpp
@@ -277,13 +277,6 @@ SEQ_FUNC seq_str_t seq_str_str(seq_str_t s, seq_str_t format, bool *error) {
   return fmt_conv(t, format, error);
 }
 
-SEQ_FUNC seq_int_t seq_int_from_str(seq_str_t s, const char **e, int base) {
-  seq_int_t result;
-  auto r = fast_float::from_chars(s.str, s.str + s.len, result, base);
-  *e = (r.ec == std::errc()) ? r.ptr : s.str;
-  return result;
-}
-
 SEQ_FUNC double seq_float_from_str(seq_str_t s, const char **e) {
   double result;
   auto r = fast_float::from_chars(s.str, s.str + s.len, result);

--- a/stdlib/internal/builtin.codon
+++ b/stdlib/internal/builtin.codon
@@ -549,7 +549,6 @@ def _parse_int(s: str, base: int = 10, T: type = int):
         acc = acc * U(base) + U(d)
         p += 1
 
-
     if (not saw_digit) or prev_underscore:
         invalid(s, base)
 

--- a/stdlib/internal/builtin.codon
+++ b/stdlib/internal/builtin.codon
@@ -511,7 +511,7 @@ def _parse_int(s: str, base: int = 10, T: type = int):
     cutlim = U()
     have_cutoff = False
 
-    if U(base) <= limit:
+    if _width(T) > 5 or int(base) <= int(limit):
         cutoff = limit // U(base)
         cutlim = limit % U(base)
         have_cutoff = True

--- a/stdlib/internal/builtin.codon
+++ b/stdlib/internal/builtin.codon
@@ -373,93 +373,219 @@ def pow(base: int, exp: int, mod: Optional[int] = None):
         exp >>= 1
     return result % mod if mod is not None else result
 
+_CHAR_0: Literal[int] = 48
+_CHAR_9: Literal[int] = 57
+_CHAR_A: Literal[int] = 65
+_CHAR_a: Literal[int] = 97
+_CHAR_Z: Literal[int] = 90
+_CHAR_z: Literal[int] = 122
+_CHAR_X: Literal[int] = 88
+_CHAR_x: Literal[int] = 120
+_CHAR_B: Literal[int] = 66
+_CHAR_b: Literal[int] = 98
+_CHAR_O: Literal[int] = 79
+_CHAR_o: Literal[int] = 111
+
+_CHAR_UNDERSCORE: Literal[int] = 95
+_CHAR_POS: Literal[int] = 43
+_CHAR_NEG: Literal[int] = 45
+
+def _parse_int(s: str, base: int = 10, T: type = int):
+
+    def _digit_value(c: byte):
+        if byte(_CHAR_0) <= c and c <= byte(_CHAR_9):
+            return int(c) - _CHAR_0
+        if byte(_CHAR_A) <= c and c <= byte(_CHAR_Z):
+            return int(c) - _CHAR_A + 10
+        if byte(_CHAR_a) <= c and c <= byte(_CHAR_z):
+            return int(c) - _CHAR_a + 10
+        return -1
+
+    def _isspace(c: byte):
+        '''
+        space (0x20, ' ')
+        form feed (0x0c, '\f')
+        line feed (0x0a, '\n')
+        carriage return (0x0d, '\r')
+        horizontal tab (0x09, '\t')
+        vertical tab (0x0b, '\v')
+        '''
+        return (c == byte(0x20) or c == byte(0x0c) or
+                c == byte(0x0a) or c == byte(0x0d) or
+                c == byte(0x09) or c == byte(0x0b))
+
+    def _limit(neg: bool, T: type):
+        if T is int:
+            if neg:
+                return UInt[64](0x8000000000000000)
+            else:
+                return UInt[64](0x7FFFFFFFFFFFFFFF)
+        elif T is byte:
+            return byte(0xFF)
+        elif isinstance(T, Int):
+            U = UInt[T.N]
+            n = U(1) << (U(T.N) - U(1))
+            return n if neg else n - U(1)
+        elif isinstance(T, UInt):
+            return ~T(0)
+        else:
+            compile_error("invalid integer type: " + T.__name__)
+
+    def _signed(T: type) -> Literal[bool]:
+        return T is int or isinstance(T, Int)
+
+    def _width(T: type) -> Literal[int]:
+        if T is int:
+            return 64
+        elif T is byte:
+            return 8
+        elif isinstance(T, Int) or isinstance(T, UInt):
+            return T.N
+        else:
+            compile_error("invalid integer type: " + T.__name__)
+
+    # argument check
+    if base != 0 and (base < 2 or base > 36):
+        raise ValueError("int() base must be >= 2 and <= 36, or 0")
+
+    p = s.ptr
+    end = p + s.__len__()
+
+    # skip leading whitespace
+    while p < end and _isspace(p[0]):
+        p += 1
+
+    # sign
+    neg = False
+    if p < end and (p[0] == _CHAR_POS or p[0] == _CHAR_NEG):
+        neg = (p[0] == _CHAR_NEG)
+        p += 1
+
+    if T is byte or isinstance(T, UInt):
+        if neg:
+            raise OverflowError("type '" + T.__name__ + "' does not support negative values")
+
+    base0_leading_zero = False
+
+    # base detection / prefix handling
+    if base == 0:
+        base = 10
+        if (end - p) >= 2 and p[0] == _CHAR_0:
+            if p[1] == _CHAR_x or p[1] == _CHAR_X:
+                base = 16
+                p += 2
+                if p < end and p[0] == _CHAR_UNDERSCORE:
+                    p += 1
+            elif p[1] == _CHAR_b or p[1] == _CHAR_B:
+                base = 2
+                p += 2
+                if p < end and p[0] == _CHAR_UNDERSCORE:
+                    p += 1
+            elif p[1] == _CHAR_o or p[1] == _CHAR_O:
+                base = 8
+                p += 2
+                if p < end and p[0] == _CHAR_UNDERSCORE:
+                    p += 1
+            else:
+                base0_leading_zero = True
+    else:
+        if (base == 16 and (end - p) >= 2 and
+            p[0] == _CHAR_0 and (p[1] == _CHAR_x or p[1] == _CHAR_X)):
+            p += 2
+            if p < end and p[0] == _CHAR_UNDERSCORE:
+                p += 1
+        elif (base == 8 and (end - p) >= 2 and
+              p[0] == _CHAR_0 and (p[1] == _CHAR_o or p[1] == _CHAR_O)):
+            p += 2
+            if p < end and p[0] == _CHAR_UNDERSCORE:
+                p += 1
+        elif (base == 2 and (end - p) >= 2 and
+              p[0] == _CHAR_0 and (p[1] == _CHAR_b or p[1] == _CHAR_B)):
+            p += 2
+            if p < end and p[0] == _CHAR_UNDERSCORE:
+                p += 1
+
+    limit = _limit(neg, T)
+    U = type(limit)
+    acc = U()
+
+    saw_digit = False
+    prev_underscore = False
+
+    def invalid(s: str, base: int):
+        raise ValueError(f"invalid literal for int() with base {base}: {s.__repr__()}")
+
+    def overflow(T: type):
+        raise OverflowError("value too large to fit into type: " + T.__name__)
+
+    while p < end:
+        c = p[0]
+
+        if c == _CHAR_UNDERSCORE:
+            if (not saw_digit) or prev_underscore:
+                invalid(s, base)
+            prev_underscore = True
+            p += 1
+            continue
+
+        d = _digit_value(c)
+        if d < 0 or d >= base:
+            break
+
+        if base0_leading_zero and d != 0:
+            invalid(s, base);
+
+        saw_digit = True
+        prev_underscore = False
+
+        # handle very small int's for which single digit may overflow
+        if _width(T) <= 5:
+            if d > int(limit):
+                overflow(T)
+
+        if acc > (limit - U(d)) // U(base):
+            overflow(T)
+
+        acc = acc * U(base) + U(d)
+        p += 1
+
+
+    if (not saw_digit) or prev_underscore:
+        invalid(s, base)
+
+    # skip trailing whitespace
+    while p < end and _isspace(p[0]):
+        p += 1
+
+    if p != end:
+        invalid(s, base)
+
+    if _signed(T):
+        if neg:
+            abs_min = limit + U(1)
+            if acc == abs_min:
+                return T(_limit(True, T))
+            else:
+                return -T(acc)
+        else:
+            return T(acc)
+    else:
+        return acc
+
 @extend
 class int:
     def _from_str(s: str, base: int):
-        def parse_error(s: str, base: int):
-            raise ValueError(
-                f"invalid literal for int() with base {base}: {s.__repr__()}"
-            )
+        return _parse_int(s, base)
 
-        if base < 0 or base > 36 or base == 1:
-            raise ValueError("int() base must be >= 2 and <= 36, or 0")
+@extend
+class Int:
+    def _from_str(s: str, base: int):
+        return _parse_int(s, base, Int[N])
 
-        s0 = s
-        base0 = base
-        s = s.strip()
-        n = len(s)
-        negate = False
-
-        if base == 0:
-            # skip leading sign
-            o = 0
-            if n >= 1 and (s.ptr[0] == byte(43) or s.ptr[0] == byte(45)):
-                o = 1
-
-            # detect base from prefix
-            if n >= o + 1 and s.ptr[o] == byte(48):  # '0'
-                if n < o + 2:
-                    parse_error(s0, base)
-
-                if s.ptr[o + 1] == byte(98) or s.ptr[o + 1] == byte(66):  # 'b'/'B'
-                    base = 2
-                elif s.ptr[o + 1] == byte(111) or s.ptr[o + 1] == byte(79):  # 'o'/'O'
-                    base = 8
-                elif s.ptr[o + 1] == byte(120) or s.ptr[o + 1] == byte(88):  # 'x'/'X'
-                    base = 16
-                else:
-                    parse_error(s0, base)
-            else:
-                base = 10
-
-        if base == 2 or base == 8 or base == 16:
-            if base == 2:
-                C_LOWER = byte(98)  # 'b'
-                C_UPPER = byte(66)  # 'B'
-            elif base == 8:
-                C_LOWER = byte(111)  # 'o'
-                C_UPPER = byte(79)   # 'O'
-            else:
-                C_LOWER = byte(120)  # 'x'
-                C_UPPER = byte(88)   # 'X'
-
-            def check_digit(d: byte, base: int):
-                if base == 2:
-                    return d == byte(48) or d == byte(49)
-                elif base == 8:
-                    return byte(48) <= d <= byte(55)
-                elif base == 16:
-                    return ((byte(48) <= d <= byte(57)) or
-                            (byte(97) <= d <= byte(102)) or
-                            (byte(65) <= d <= byte(70)))
-                return False
-
-            if (n >= 4 and
-                (s.ptr[0] == byte(43) or s.ptr[0] == byte(45)) and
-                s.ptr[1] == byte(48) and
-                (s.ptr[2] == C_LOWER or s.ptr[2] == C_UPPER)):  # '+0b' etc.
-                if not check_digit(s.ptr[3], base):
-                    parse_error(s0, base0)
-                negate = (s.ptr[0] == byte(45))
-                s = str(s.ptr + 3, n - 3)
-            elif (n >= 3 and
-                  s.ptr[0] == byte(48) and
-                  (s.ptr[1] == C_LOWER or s.ptr[1] == C_UPPER)):  # '0b' etc.
-                if not check_digit(s.ptr[3], base):
-                    parse_error(s0, base0)
-                s = str(s.ptr + 2, n - 2)
-
-        end = cobj()
-        result = _C.seq_int_from_str(s, __ptr__(end), i32(base))
-        n = len(s)
-
-        if n == 0 or end != s.ptr + n:
-            parse_error(s0, base0)
-
-        if negate:
-            result = -result
-
-        return result
+@extend
+class UInt:
+    def _from_str(s: str, base: int):
+        return _parse_int(s, base, UInt[N])
 
 @extend
 class float:

--- a/stdlib/internal/builtin.codon
+++ b/stdlib/internal/builtin.codon
@@ -506,12 +506,20 @@ def _parse_int(s: str, base: int = 10, T: type = int):
 
     limit = _limit(neg, T)
     U = type(limit)
-    cutoff = limit // U(base)
-    cutlim = limit % U(base)
-    acc = U()
 
+    cutoff = U()
+    cutlim = U()
+    have_cutoff = False
+
+    if U(base) <= limit:
+        cutoff = limit // U(base)
+        cutlim = limit % U(base)
+        have_cutoff = True
+
+    acc = U()
     saw_digit = False
     prev_underscore = False
+    overflow = False
 
     def invalid(s: str, base: int):
         raise ValueError(f"invalid literal for int() with base {base}: {s.__repr__()}")
@@ -531,17 +539,22 @@ def _parse_int(s: str, base: int = 10, T: type = int):
             break
 
         if base0_leading_zero and d != 0:
-            invalid(s, base);
+            invalid(s, base)
 
-        saw_digit = True
-        prev_underscore = False
+        if _width(T) <= 5 and d > int(limit):
+            overflow = True
 
-        if ((acc > cutoff) or
-            (acc == cutoff and d > int(cutlim)) or
-            (_width(T) <= 5 and d > int(limit))):
-            raise OverflowError("value does not fit into type: " + T.__name__)
+        if have_cutoff:
+            if ((acc > cutoff) or
+                (acc == cutoff and d > int(cutlim))):
+                overflow = True
+        else:
+            if acc:
+                overflow = True
 
         acc = acc * U(base) + U(d)
+        saw_digit = True
+        prev_underscore = False
         p += 1
 
     if (not saw_digit) or prev_underscore:
@@ -553,6 +566,9 @@ def _parse_int(s: str, base: int = 10, T: type = int):
 
     if p != end:
         invalid(s, base)
+
+    if overflow:
+        raise OverflowError(f"value does not fit into type {T.__name__}: {s.__repr__()}")
 
     if _signed(T):
         if neg:

--- a/stdlib/internal/builtin.codon
+++ b/stdlib/internal/builtin.codon
@@ -461,13 +461,12 @@ def _parse_int(s: str, base: int = 10, T: type = int):
         neg = (p[0] == _CHAR_NEG)
         p += 1
 
-    if T is byte or isinstance(T, UInt):
+    if not _signed(T):
         if neg:
-            raise OverflowError("type '" + T.__name__ + "' does not support negative values")
-
-    base0_leading_zero = False
+            raise OverflowError("type " + T.__name__ + " does not support negative values")
 
     # base detection / prefix handling
+    base0_leading_zero = False
     if base == 0:
         base = 10
         if (end - p) >= 2 and p[0] == _CHAR_0:
@@ -507,6 +506,8 @@ def _parse_int(s: str, base: int = 10, T: type = int):
 
     limit = _limit(neg, T)
     U = type(limit)
+    cutoff = limit // U(base)
+    cutlim = limit % U(base)
     acc = U()
 
     saw_digit = False
@@ -514,9 +515,6 @@ def _parse_int(s: str, base: int = 10, T: type = int):
 
     def invalid(s: str, base: int):
         raise ValueError(f"invalid literal for int() with base {base}: {s.__repr__()}")
-
-    def overflow(T: type):
-        raise OverflowError("value too large to fit into type: " + T.__name__)
 
     while p < end:
         c = p[0]
@@ -538,13 +536,10 @@ def _parse_int(s: str, base: int = 10, T: type = int):
         saw_digit = True
         prev_underscore = False
 
-        # handle very small int's for which single digit may overflow
-        if _width(T) <= 5:
-            if d > int(limit):
-                overflow(T)
-
-        if acc > (limit - U(d)) // U(base):
-            overflow(T)
+        if ((acc > cutoff) or
+            (acc == cutoff and d > int(cutlim)) or
+            (_width(T) <= 5 and d > int(limit))):
+            raise OverflowError("value does not fit into type: " + T.__name__)
 
         acc = acc * U(base) + U(d)
         p += 1

--- a/stdlib/internal/c_stubs.codon
+++ b/stdlib/internal/c_stubs.codon
@@ -31,11 +31,6 @@ def seq_str_ptr(a: cobj, fmt: str, error: Ptr[bool]) -> str:
 
 @nocapture
 @C
-def seq_int_from_str(a: str, b: Ptr[cobj], c: i32) -> int:
-    pass
-
-@nocapture
-@C
 def seq_float_from_str(a: str, b: Ptr[cobj]) -> float:
     pass
 

--- a/stdlib/internal/types/intn.codon
+++ b/stdlib/internal/types/intn.codon
@@ -83,20 +83,9 @@ class Int:
             return Int._sext(what, 64, N)
 
     @overload
-    def __new__(what: str) -> Int[N]:
+    def __new__(what: str, base: int = 10) -> Int[N]:
         _check_bitwidth(N)
-        ret = Int[N]()
-        i = 0
-        sign = Int[N](1)
-        if i < what.len and what.ptr[0] == byte(45):
-            sign = Int[N](-1)
-            i += 1
-        while i < what.len:
-            if what.ptr[i] < byte(48) or what.ptr[i] >= byte(58):
-                raise ValueError("Invalid integer string")
-            ret = ret * Int[N](10) + Int[N](int(what.ptr[i]) - 48)
-            i += 1
-        return sign * ret
+        return Int[N]._from_str(what, base)
 
     def __int__(self) -> int:
         if N > 64:
@@ -181,9 +170,8 @@ class Int:
     def _floordiv(self, other: Int[N]) -> Int[N]:
         %0 = sdiv i{=N} %self, %other
         ret i{=N} %0
+
     def __floordiv__(self, other: Int[N]) -> Int[N]:
-        if N > 128:
-            compile_error("division is not supported on Int[N] when N > 128")
         return self._floordiv(other)
 
     @pure
@@ -411,9 +399,9 @@ class UInt:
         else:
             return UInt[N](Int._sext(what, 64, N))
 
-    def __new__(what: str) -> UInt[N]:
+    def __new__(what: str, base: int = 10) -> UInt[N]:
         _check_bitwidth(N)
-        return UInt[N](Int[N](what))
+        return UInt[N]._from_str(what, base)
 
     def __int__(self) -> int:
         if N > 64:
@@ -494,9 +482,8 @@ class UInt:
     def _floordiv(self, other: UInt[N]) -> UInt[N]:
         %0 = udiv i{=N} %self, %other
         ret i{=N} %0
+
     def __floordiv__(self, other: UInt[N]) -> UInt[N]:
-        if N > 128:
-            compile_error("division is not supported on UInt[N] when N > 128")
         return self._floordiv(other)
 
     @pure

--- a/stdlib/internal/types/intn.codon
+++ b/stdlib/internal/types/intn.codon
@@ -189,8 +189,6 @@ class Int:
         ret i{=N} %0
 
     def __mod__(self, other: Int[N]) -> Int[N]:
-        if N > 128:
-            compile_error("modulus is not supported on Int[N] when N > 128")
         return self._mod(other)
 
     def __divmod__(self, other: Int[N]) -> Tuple[Int[N], Int[N]]:
@@ -499,9 +497,8 @@ class UInt:
     def _mod(self, other: UInt[N]) -> UInt[N]:
         %0 = urem i{=N} %self, %other
         ret i{=N} %0
+
     def __mod__(self, other: UInt[N]) -> UInt[N]:
-        if N > 128:
-            compile_error("modulus is not supported on UInt[N] when N > 128")
         return self._mod(other)
 
     def __divmod__(self, other: UInt[N]) -> Tuple[UInt[N], UInt[N]]:

--- a/test/core/bltin.codon
+++ b/test/core/bltin.codon
@@ -898,6 +898,787 @@ def test_num_from_str():
         assert str(e) == "could not convert string to float: ''"
 
 @test
+def test_num_from_str_extended():
+    # Basic decimal
+    assert int("0") == 0
+    assert int("1") == 1
+    assert int("123") == 123
+    assert int("+123") == 123
+    assert int("-123") == -123
+    assert int("   123") == 123
+    assert int("123   ") == 123
+    assert int("   +123   ") == 123
+    assert int("   -123   ") == -123
+
+    # Explicit bases
+    assert int("10", base=2) == 2
+    assert int("10", base=3) == 3
+    assert int("10", base=8) == 8
+    assert int("10", base=10) == 10
+    assert int("10", base=16) == 16
+    assert int("10", base=36) == 36
+    assert int("ff", base=16) == 255
+    assert int("FF", base=16) == 255
+    assert int("z", base=36) == 35
+    assert int("Z", base=36) == 35
+
+    # base=0 prefix detection
+    assert int("123", base=0) == 123
+    assert int("0b1010", base=0) == 10
+    assert int("0B1010", base=0) == 10
+    assert int("0o777", base=0) == 511
+    assert int("0O777", base=0) == 511
+    assert int("0xdeadbeef", base=0) == 3735928559
+    assert int("0XDEADBEEF", base=0) == 3735928559
+    assert int("-0b1010", base=0) == -10
+    assert int("-0o777", base=0) == -511
+    assert int("-0x100", base=0) == -256
+
+    # Matching explicit prefixes
+    assert int("0b1010", base=2) == 10
+    assert int("0o777", base=8) == 511
+    assert int("0xff", base=16) == 255
+    assert int("0X_FF", base=16) == 255
+
+    # Underscores
+    assert int("1_000") == 1000
+    assert int("12_34_56") == 123456
+    assert int("+1_000") == 1000
+    assert int("-1_000") == -1000
+    assert int("0b1010_0101", base=0) == 165
+    assert int("0o12_34", base=0) == 668
+    assert int("0xDEAD_BEEF", base=0) == 3735928559
+    assert int("0x_FF", base=0) == 255
+    assert int("0b_1010", base=0) == 10
+    assert int("0o_777", base=0) == 511
+    assert int("z_z", base=36) == 1295
+
+    # Typed constructors: unsigned
+    assert UInt[8]("0") == UInt[8](0)
+    assert UInt[8]("255") == UInt[8](255)
+    assert UInt[8]("ff", base=16) == UInt[8](255)
+    assert UInt[8]("0xff", base=0) == UInt[8](255)
+    assert UInt[8]("0b1111_1111", base=0) == UInt[8](255)
+
+    assert UInt[16]("65535") == UInt[16](65535)
+    assert UInt[16]("ffff", base=16) == UInt[16](65535)
+    assert UInt[16]("0xffff", base=0) == UInt[16](65535)
+
+    assert UInt[32]("123", base=16) == UInt[32](0x123)
+    assert UInt[32]("4294967295") == UInt[32](4294967295)
+    assert UInt[32]("ffffffff", base=16) == UInt[32](4294967295)
+    assert UInt[32]("0xffffffff", base=0) == UInt[32](4294967295)
+
+    assert UInt[64]("18446744073709551615") == UInt[64](18446744073709551615)
+    assert UInt[64]("ffffffffffffffff", base=16) == UInt[64](18446744073709551615)
+    assert UInt[64]("0xffffffffffffffff", base=0) == UInt[64](18446744073709551615)
+
+    # Typed constructors: signed
+    assert Int[8]("127") == Int[8](127)
+    assert Int[8]("-128") == Int[8](-128)
+    assert Int[8]("0x7f", base=0) == Int[8](127)
+    assert Int[8]("-0x80", base=0) == Int[8](-128)
+
+    assert Int[16]("32767") == Int[16](32767)
+    assert Int[16]("-32768") == Int[16](-32768)
+
+    assert Int[32]("2147483647") == Int[32](2147483647)
+    assert Int[32]("-2147483648") == Int[32](-2147483648)
+    assert Int[32]("0x7fffffff", base=0) == Int[32](2147483647)
+    assert Int[32]("-0x80000000", base=0) == Int[32](-2147483648)
+
+    assert Int[64]("9223372036854775807") == Int[64](9223372036854775807)
+    assert Int[64]("-9223372036854775808") == Int[64](-9223372036854775808)
+    assert Int[64]("0x7fffffffffffffff", base=0) == Int[64](9223372036854775807)
+    assert Int[64]("-0x8000000000000000", base=0) == Int[64](-9223372036854775808)
+
+    # Boundary values in binary/octal
+    assert UInt[8]("11111111", base=2) == UInt[8](255)
+    assert Int[8]("1111111", base=2) == Int[8](127)
+    assert Int[8]("-10000000", base=2) == Int[8](-128)
+
+    assert UInt[16]("177777", base=8) == UInt[16](65535)
+    assert Int[16]("77777", base=8) == Int[16](32767)
+    assert Int[16]("-100000", base=8) == Int[16](-32768)
+
+    # Invalid literals
+    try:
+        int("")
+        assert False
+    except ValueError:
+        pass
+
+    try:
+        int("   ")
+        assert False
+    except ValueError:
+        pass
+
+    try:
+        int("+")
+        assert False
+    except ValueError:
+        pass
+
+    try:
+        int("-")
+        assert False
+    except ValueError:
+        pass
+
+    try:
+        int("_123")
+        assert False
+    except ValueError:
+        pass
+
+    try:
+        int("123_")
+        assert False
+    except ValueError:
+        pass
+
+    try:
+        int("1__23")
+        assert False
+    except ValueError:
+        pass
+
+    try:
+        int("+_123")
+        assert False
+    except ValueError:
+        pass
+
+    try:
+        int("-_123")
+        assert False
+    except ValueError:
+        pass
+
+    try:
+        int("12 34")
+        assert False
+    except ValueError:
+        pass
+
+    try:
+        int("123abc")
+        assert False
+    except ValueError:
+        pass
+
+    try:
+        int("0x", base=0)
+        assert False
+    except ValueError:
+        pass
+
+    try:
+        int("0x_", base=0)
+        assert False
+    except ValueError:
+        pass
+
+    try:
+        int("0b", base=0)
+        assert False
+    except ValueError:
+        pass
+
+    try:
+        int("0b_", base=0)
+        assert False
+    except ValueError:
+        pass
+
+    try:
+        int("0o", base=0)
+        assert False
+    except ValueError:
+        pass
+
+    try:
+        int("0o_", base=0)
+        assert False
+    except ValueError:
+        pass
+
+    try:
+        int("2", base=2)
+        assert False
+    except ValueError:
+        pass
+
+    try:
+        int("8", base=8)
+        assert False
+    except ValueError:
+        pass
+
+    try:
+        int("g", base=16)
+        assert False
+    except ValueError:
+        pass
+
+    try:
+        int("z", base=35)
+        assert False
+    except ValueError:
+        pass
+
+    # Invalid bases
+    try:
+        int("123", base=1)
+        assert False
+    except ValueError:
+        pass
+
+    try:
+        int("123", base=37)
+        assert False
+    except ValueError:
+        pass
+
+    try:
+        int("123", base=-2)
+        assert False
+    except ValueError:
+        pass
+
+    # Python-style base=0 should reject old-style leading-zero decimals
+    try:
+        int("010", base=0)
+        assert False
+    except ValueError:
+        pass
+
+    try:
+        int("00_10", base=0)
+        assert False
+    except ValueError:
+        pass
+
+    # Signed overflow
+    try:
+        Int[8]("128")
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        Int[8]("-129")
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        Int[16]("32768")
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        Int[16]("-32769")
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        Int[32]("2147483648")
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        Int[32]("-2147483649")
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        Int[64]("9223372036854775808")
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        Int[64]("-9223372036854775809")
+        assert False
+    except OverflowError:
+        pass
+
+    # Unsigned overflow
+    try:
+        UInt[8]("256")
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        UInt[16]("65536")
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        UInt[32]("4294967296")
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        UInt[64]("18446744073709551616")
+        assert False
+    except OverflowError:
+        pass
+
+    # Negative unsigned
+    try:
+        UInt[8]("-1")
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        UInt[32]("-123")
+        assert False
+    except OverflowError:
+        pass
+
+    # Overflow with prefixes/underscores
+    try:
+        UInt[8]("0x100", base=0)
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        Int[8]("0x80", base=0)
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        Int[8]("-0x81", base=0)
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        UInt[32]("0x1_0000_0000", base=0)
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        Int[32]("0x8000_0000", base=0)
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        Int[32]("-0x8000_0001", base=0)
+        assert False
+    except OverflowError:
+        pass
+
+    # Binary/octal overflow
+    try:
+        UInt[8]("100000000", base=2)
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        Int[8]("10000000", base=2)
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        Int[8]("-10000001", base=2)
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        UInt[16]("200000", base=8)
+        assert False
+    except OverflowError:
+        pass
+
+    # Int[4]: range [-8, 7]
+    assert Int[4]("0") == Int[4](0)
+    assert Int[4]("7") == Int[4](7)
+    assert Int[4]("-8") == Int[4](-8)
+    assert Int[4]("0b111", base=0) == Int[4](7)
+    assert Int[4]("-0b1000", base=0) == Int[4](-8)
+    assert Int[4]("0x7", base=0) == Int[4](7)
+    assert Int[4]("-0x8", base=0) == Int[4](-8)
+
+    try:
+        Int[4]("8")
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        Int[4]("-9")
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        Int[4]("0b1000", base=0)
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        Int[4]("-0b1001", base=0)
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        Int[4]("0x8", base=0)
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        Int[4]("-0x9", base=0)
+        assert False
+    except OverflowError:
+        pass
+
+    # UInt[4]: range [0, 15]
+    assert UInt[4]("0") == UInt[4](0)
+    assert UInt[4]("15") == UInt[4](15)
+    assert UInt[4]("0xf", base=0) == UInt[4](15)
+    assert UInt[4]("0b1111", base=0) == UInt[4](15)
+
+    try:
+        UInt[4]("16")
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        UInt[4]("0x10", base=0)
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        UInt[4]("0b10000", base=0)
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        UInt[4]("z", base=36)
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        UInt[4]("-1")
+        assert False
+    except OverflowError:
+        pass
+
+    # UInt[5]: range [0, 31]
+    assert UInt[5]("31") == UInt[5](31)
+    assert UInt[5]("v", base=36) == UInt[5](31)
+
+    try:
+        UInt[5]("32")
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        UInt[5]("w", base=36)
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        UInt[5]("z", base=36)
+        assert False
+    except OverflowError:
+        pass
+
+    # UInt[6]: range [0, 63]
+    assert UInt[6]("z", base=36) == UInt[6](35)
+    assert UInt[6]("10", base=36) == UInt[6](36)
+    assert UInt[6]("1r", base=36) == UInt[6](63)
+
+    try:
+        UInt[6]("1s", base=36)
+        assert False
+    except OverflowError:
+        pass
+
+    # Int[5]: range [-16, 15]
+    assert Int[5]("15") == Int[5](15)
+    assert Int[5]("-16") == Int[5](-16)
+    assert Int[5]("f", base=16) == Int[5](15)
+    assert Int[5]("-10", base=16) == Int[5](-16)
+
+    try:
+        Int[5]("16")
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        Int[5]("-17")
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        Int[5]("g", base=17)
+        assert False
+    except OverflowError:
+        pass
+
+    # Int[7]: range [-64, 63]
+    assert Int[7]("63") == Int[7](63)
+    assert Int[7]("-64") == Int[7](-64)
+    assert Int[7]("1r", base=36) == Int[7](63)
+    assert Int[7]("-1s", base=36) == Int[7](-64)
+
+    try:
+        Int[7]("64")
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        Int[7]("-65")
+        assert False
+    except OverflowError:
+        pass
+
+    # UInt[128]: max = 2^128 - 1
+    u128_max = "340282366920938463463374607431768211455"
+    assert str(UInt[128]("0")) == "0"
+    assert str(UInt[128](u128_max)) == u128_max
+    assert str(UInt[128]("0xffffffffffffffffffffffffffffffff", base=0)) == u128_max
+    assert str(UInt[128]("ffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff", base=16)) == u128_max
+    assert str(UInt[128]("0b" + "1" * 128, base=0)) == u128_max
+
+    try:
+        UInt[128]("340282366920938463463374607431768211456")
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        UInt[128]("0x100000000000000000000000000000000", base=0)
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        UInt[128]("0b1" + "0" * 128, base=0)
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        UInt[128]("-1")
+        assert False
+    except OverflowError:
+        pass
+
+    # Int[128]: range [-(2^127), 2^127 - 1]
+    i128_max = "170141183460469231731687303715884105727"
+    i128_min = "-170141183460469231731687303715884105728"
+
+    assert str(Int[128]("0")) == "0"
+    assert str(Int[128](i128_max)) == i128_max
+    assert str(Int[128](i128_min)) == i128_min
+    assert str(Int[128]("0x7fffffffffffffffffffffffffffffff", base=0)) == i128_max
+    assert str(Int[128]("-0x80000000000000000000000000000000", base=0)) == i128_min
+    assert str(Int[128]("0b" + "1" * 127, base=0)) == i128_max
+    assert str(Int[128]("-0b1" + "0" * 127, base=0)) == i128_min
+
+    try:
+        Int[128]("170141183460469231731687303715884105728")
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        Int[128]("-170141183460469231731687303715884105729")
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        Int[128]("0x80000000000000000000000000000000", base=0)
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        Int[128]("-0x80000000000000000000000000000001", base=0)
+        assert False
+    except OverflowError:
+        pass
+
+    # UInt[256]: max = 2^256 - 1
+    u256_max = "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+
+    assert str(UInt[256]("0")) == "0"
+    assert str(UInt[256](u256_max)) == u256_max
+    assert str(UInt[256](
+        "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        base=0,
+    )) == u256_max
+    assert str(UInt[256](
+        "ffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff",
+        base=16,
+    )) == u256_max
+    assert str(UInt[256]("0b" + "1" * 256, base=0)) == u256_max
+
+    try:
+        UInt[256](
+            "115792089237316195423570985008687907853269984665640564039457584007913129639936"
+        )
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        UInt[256](
+            "0x10000000000000000000000000000000000000000000000000000000000000000",
+            base=0,
+        )
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        UInt[256]("0b1" + "0" * 256, base=0)
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        UInt[256]("-1")
+        assert False
+    except OverflowError:
+        pass
+
+    # Int[256]: range [-(2^255), 2^255 - 1]
+    i256_max = "57896044618658097711785492504343953926634992332820282019728792003956564819967"
+    i256_min = "-57896044618658097711785492504343953926634992332820282019728792003956564819968"
+
+    assert str(Int[256]("0")) == "0"
+    assert str(Int[256](i256_max)) == i256_max
+    assert str(Int[256](i256_min)) == i256_min
+    assert str(Int[256](
+        "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        base=0,
+    )) == i256_max
+    assert str(Int[256](
+        "-0x8000000000000000000000000000000000000000000000000000000000000000",
+        base=0,
+    )) == i256_min
+    assert str(Int[256]("0b" + "1" * 255, base=0)) == i256_max
+    assert str(Int[256]("-0b1" + "0" * 255, base=0)) == i256_min
+
+    try:
+        Int[256](
+            "57896044618658097711785492504343953926634992332820282019728792003956564819968"
+        )
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        Int[256](
+            "-57896044618658097711785492504343953926634992332820282019728792003956564819969"
+        )
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        Int[256](
+            "0x8000000000000000000000000000000000000000000000000000000000000000",
+            base=0,
+        )
+        assert False
+    except OverflowError:
+        pass
+
+    try:
+        Int[256](
+            "-0x8000000000000000000000000000000000000000000000000000000000000001",
+            base=0,
+        )
+        assert False
+    except OverflowError:
+        pass
+
+    # extra tests from PR #786
+    assert int("0b0", 0) == 0
+    assert int("0b1", 0) == 1
+    assert int("0b1101", 0) == 13
+    assert int("+0b1101", 0) == 13
+    assert int("-0b1101", 0) == -13
+
+    assert int("7", 0) == 7
+    assert int("42", 0) == 42
+    assert int("12345", 0) == 12345
+    assert int("+67890", 0) == 67890
+    assert int("-24680", 0) == -24680
+
+    assert int("0o7", 0) == 7
+    assert int("0o123", 0) == 83
+    assert int("0o707", 0) == 455
+    assert int("+0o710", 0) == 456
+    assert int("-0o765", 0) == -501
+
+    assert int("0xA", 0) == 10
+    assert int("0xABCD", 0) == 43981
+    assert int("0xFFF", 0) == 4095
+    assert int("+0x1234", 0) == 4660
+    assert int("-0xFF", 0) == -255
+
+    assert int("1_0", 2) == 2
+    assert int("10_01", 2) == 9
+    assert int("101_101", 2) == 45
+    assert int("0b1_101", 0) == 13
+    assert int("-0b101_011", 0) == -43
+
+    assert int("1_2", 8) == 10
+    assert int("12_3", 8) == 83
+    assert int("7_07", 8) == 455
+    assert int("0o1_23", 0) == 83
+    assert int("-0o7_10", 0) == -456
+
+    assert int("1_A", 16) == 26
+    assert int("AB_CD", 16) == 43981
+    assert int("F_FF", 16) == 4095
+    assert int("0x1_A", 0) == 26
+    assert int("-0xF_F", 0) == -255
+
+    assert int("1_2") == 12
+    assert int("12_34") == 1234
+    assert int("123_456") == 123456
+    assert int("+1_000_001") == 1000001
+    assert int("-9_87_65") == -98765
+
+@test
 def test_files(open_fn, append_allowed: bool = True):
     path = 'build/testfile.txt'
     f = open_fn(path, 'w')
@@ -963,6 +1744,7 @@ test_reversed()
 test_divmod()
 test_pow()
 test_num_from_str()
+test_num_from_str_extended()
 test_files(open)
 import gzip
 test_files(gzip.open)

--- a/test/core/bltin.codon
+++ b/test/core/bltin.codon
@@ -1678,6 +1678,20 @@ def test_num_from_str_extended():
     assert int("+1_000_001") == 1000001
     assert int("-9_87_65") == -98765
 
+    # If it's both an overflow and invalid value, make
+    # sure the invalid value exception gets priority
+    try:
+        UInt[16]('9999999999999999xxxx')
+        assert False
+    except ValueError:  # not OverflowError
+        pass
+
+    try:
+        UInt[16]('9999999999999999')
+        assert False
+    except OverflowError:
+        pass
+
 @test
 def test_files(open_fn, append_allowed: bool = True):
     path = 'build/testfile.txt'

--- a/test/parser/typecheck/test_basic.codon
+++ b/test/parser/typecheck/test_basic.codon
@@ -34,8 +34,10 @@ class int:
 print(123_456test) #: TEST: 123456
 
 #%% int_large,barebones
-print(1844674407_3709551999)  #: 383
 print(1844674407_3709551999i256)  #: 18446744073709551999
+
+#%% int_large_overflow,barebones
+print(1844674407_3709551999)  #! integer '18446744073709551999' cannot fit into 64-bit integer
 
 #%% float,barebones
 f = 1.11


### PR DESCRIPTION
- Supports underscores and prefixes as in Python
- Supports parsing arbitrary int types (e.g. `u32`, `i128` etc.)
- Adds many more tests