### PR TITLE
JIT: remove jit dlopen global

### DIFF
--- a/codon/compiler/engine.cpp
+++ b/codon/compiler/engine.cpp
@@ -8,7 +8,7 @@
 namespace codon {
 namespace jit {
 
-Engine::Engine() : jit(), debug(nullptr) {
+Engine::Engine() : jit(), debug(nullptr), globalPrefix('\0') {
   auto eb = llvm::EngineBuilder();
   eb.setMArch(llvm::codegen::getMArch());
   eb.setMCPU(llvm::codegen::getCPUStr());
@@ -39,10 +39,10 @@ Engine::Engine() : jit(), debug(nullptr) {
   builder.setJITTargetMachineBuilder(
       llvm::orc::JITTargetMachineBuilder(target->getTargetTriple()));
   jit = llvm::cantFail(builder.create());
+  globalPrefix = layout.getGlobalPrefix();
 
-  jit->getMainJITDylib().addGenerator(
-      llvm::cantFail(llvm::orc::DynamicLibrarySearchGenerator::GetForCurrentProcess(
-          layout.getGlobalPrefix())));
+  jit->getMainJITDylib().addGenerator(llvm::cantFail(
+      llvm::orc::DynamicLibrarySearchGenerator::GetForCurrentProcess(globalPrefix)));
 
   jit->getIRTransformLayer().setTransform(
       [&](llvm::orc::ThreadSafeModule module,
@@ -64,6 +64,14 @@ llvm::Error Engine::addModule(llvm::orc::ThreadSafeModule module,
 
 llvm::Expected<llvm::orc::ExecutorAddr> Engine::lookup(llvm::StringRef name) {
   return jit->lookup(name);
+}
+
+llvm::Error Engine::addDynamicLibrary(const std::string &path) {
+  auto gen = llvm::orc::DynamicLibrarySearchGenerator::Load(path.c_str(), globalPrefix);
+  if (!gen)
+    return gen.takeError();
+  jit->getMainJITDylib().addGenerator(std::move(*gen));
+  return llvm::Error::success();
 }
 
 } // namespace jit

--- a/codon/compiler/engine.h
+++ b/codon/compiler/engine.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "codon/cir/llvm/llvm.h"
@@ -15,6 +16,7 @@ class Engine {
 private:
   std::unique_ptr<llvm::orc::LLJIT> jit;
   DebugPlugin *debug;
+  char globalPrefix;
 
 public:
   Engine();
@@ -29,6 +31,11 @@ public:
                         llvm::orc::ResourceTrackerSP rt = nullptr);
 
   llvm::Expected<llvm::orc::ExecutorAddr> lookup(llvm::StringRef name);
+
+  /// Load a dynamic library and register it with the JIT for symbol resolution.
+  /// @param path Path to the dynamic library file (.so/.dll/.dylib)
+  /// @return llvm::Error::success() on success, error code on failure
+  llvm::Error addDynamicLibrary(const std::string &path);
 };
 
 } // namespace jit

--- a/codon/compiler/jit.cpp
+++ b/codon/compiler/jit.cpp
@@ -4,6 +4,9 @@
 
 #include <sstream>
 
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Path.h"
+
 #include "codon/parser/common.h"
 #include "codon/parser/peg/peg.h"
 #include "codon/parser/visitors/doc/doc.h"
@@ -374,11 +377,82 @@ JIT::JITResult JIT::executePython(const std::string &name,
   }
 }
 
+namespace {
+
+#ifdef __APPLE__
+constexpr const char *kCodonRTBaseName = "libcodonrt.dylib";
+#else
+constexpr const char *kCodonRTBaseName = "libcodonrt.so";
+#endif
+
+} // namespace
+
+// Locate the absolute path of the Codon runtime shared library
+// (libcodonrt.so / .dylib). Tries, in order:
+//   1. <library_path()>/../<RT>     (libcodonrt sits next to libcodonc)
+//   2. <library_path()>/<RT>
+//   3. $CODON_DIR/lib/codon/<RT>
+//   4. bare soname (let the dynamic linker resolve it)
+// Returns canonicalized path on success; bare soname on failure.
+std::string findCodonRuntime() {
+  std::vector<std::string> candidates;
+
+  const std::string libcodonc = codon::ast::library_path();
+  if (!libcodonc.empty()) {
+    auto dir = llvm::sys::path::parent_path(libcodonc);
+    if (!dir.empty()) {
+      llvm::SmallString<256> p1(dir);
+      llvm::sys::path::append(p1, kCodonRTBaseName);
+      candidates.emplace_back(p1.str());
+
+      llvm::SmallString<256> p2(dir);
+      llvm::sys::path::append(p2, "..", "lib", "codon", kCodonRTBaseName);
+      candidates.emplace_back(p2.str());
+    }
+  }
+
+  if (const char *codonDir = std::getenv("CODON_DIR")) {
+    llvm::SmallString<256> p(codonDir);
+    llvm::sys::path::append(p, "lib", "codon", kCodonRTBaseName);
+    candidates.emplace_back(p.str());
+  }
+
+  for (const auto &c : candidates) {
+    if (!llvm::sys::fs::exists(c))
+      continue;
+    // Canonicalize to prevent the dynamic linker from treating two different
+    // paths to the same physical file as distinct shared objects (which would
+    // otherwise cause the runtime / Boehm GC to be loaded twice).
+    llvm::SmallString<256> real;
+    if (!llvm::sys::fs::real_path(c, real))
+      return std::string(real.str());
+    return c;
+  }
+
+  // Last resort: bare soname; rely on RUNPATH / LD_LIBRARY_PATH / ldconfig.
+  return std::string(kCodonRTBaseName);
+}
+
 } // namespace jit
 } // namespace codon
 
 void *jit_init(char *name) {
   auto jit = new codon::jit::JIT(std::string(name));
+
+  // Register libcodonrt so the JIT can resolve runtime symbols
+  // (seq_*, GC_*, ...) without requiring RTLD_GLOBAL on the Python
+  // extension. Failure here is fatal: without the runtime the JIT cannot
+  // link any compiled code.
+  const std::string rt = codon::jit::findCodonRuntime();
+  if (auto err = jit->getEngine()->addDynamicLibrary(rt)) {
+    auto info = llvm::toString(std::move(err));
+    llvm::report_fatal_error(
+        llvm::StringRef("cannot load codon runtime '" + rt + "': " + info),
+        /*gen_crash_diag=*/false);
+  }
+  if (std::getenv("CODON_JIT_DEBUG"))
+    fmt::print(stderr, "[codon::jit] loaded runtime: {}\n", rt);
+
   llvm::cantFail(jit->init());
   return jit;
 }

--- a/jit/codon/decorator.py
+++ b/jit/codon/decorator.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2022-2026 Exaloop Inc. <https://exaloop.io>
 
 from argparse import ArgumentError
-import ctypes
 import inspect
 import sys
 import os
@@ -12,8 +11,6 @@ import textwrap
 import astunparse
 import numpy as np
 from pathlib import Path
-
-sys.setdlopenflags(sys.getdlopenflags() | ctypes.RTLD_GLOBAL)
 
 from .codon_jit import JITWrapper, JITError, codon_library
 


### PR DESCRIPTION
- Background: Codon JIT previously relied on  `RTLD_GLOBAL`  when importing  codon_jit , so LLVM ORC could resolve runtime symbols from the process-wide global symbol table. This is unsafe because it changes symbol visibility for the whole Python process and pollutes the global symbol table.
- Implementation: We removed the  `RTLD_GLOBAL` requirement and switched to a layered lookup model: LLVM ORC still uses  `GetForCurrentProcess()`  for common system/Python symbols, while Codon runtime symbols are resolved by explicitly registering  `libcodonrt` as an additional dynamic library. The runtime path is discovered from the Codon install layout and canonicalized with LLVM filesystem utilities before loading. 