### PR TITLE
feat: support jitclass for native codon jit class

### DIFF
--- a/codon/compiler/jit.cpp
+++ b/codon/compiler/jit.cpp
@@ -32,17 +32,25 @@ JIT::JIT(const std::string &argv0, const std::string &mode,
                                           /*isTest=*/false,
                                           /*pyNumerics=*/false, /*pyExtension=*/false)),
       engine(std::make_unique<Engine>()), pydata(std::make_unique<PythonData>()),
-      jitClassData(std::make_unique<JITClassData>()), mode(mode), forgetful(false) {
+      jitClassData(std::make_unique<JITClassData>()),
+      contextState(std::make_shared<JITContextState>()), mode(mode), forgetful(false) {
   if (!stdlibRoot.empty())
     compiler->getCache()->fs->add_search_path(stdlibRoot);
   compiler->getLLVMVisitor()->setJIT(true);
 }
 
+JIT::~JIT() {
+  // Existing jitclass instances may outlive this engine; mark them stale.
+  contextState->alive.store(false);
+}
+
 JIT::JITClassRoot::JITClassRoot(void *ptr) : slot(std::make_unique<void *>(ptr)) {
+  // The slot stores the GC pointer value; the root range points at the slot itself.
   seq_gc_add_roots(slot.get(), slot.get() + 1);
 }
 
 JIT::JITClassRoot::~JITClassRoot() {
+  // Moving clears the source slot, so removal is only needed for active roots.
   if (slot)
     seq_gc_remove_roots(slot.get(), slot.get() + 1);
 }
@@ -56,14 +64,17 @@ JIT::JITClassRoot &JIT::JITClassRoot::operator=(JITClassRoot &&other) noexcept {
   return *this;
 }
 
-JIT::JITClassObject::JITClassObject(std::string className, std::string nativeClassName,
-                                    void *nativePtr)
-    : className(std::move(className)), nativeClassName(std::move(nativeClassName)),
-      nativePtr(nativePtr), root(nativePtr) {}
+JIT::JITClassInstance::JITClassInstance(std::shared_ptr<JITContextState> contextState,
+                                        std::string className,
+                                        std::string nativeClassName, void *nativePtr)
+    : contextState(std::move(contextState)), className(std::move(className)),
+      nativeClassName(std::move(nativeClassName)), nativePtr(nativePtr),
+      // Root construction pins the Codon object for the lifetime of this block.
+      root(nativePtr) {}
 
 void collectExecutableStmts(ast::Stmt *s, ast::SuiteStmt *final) {
-  if (cast<ast::FunctionStmt>(s) || cast<ast::ClassStmt>(s) ||
-      cast<ast::CommentStmt>(s))
+  if (ast::cast<ast::FunctionStmt>(s) || ast::cast<ast::ClassStmt>(s) ||
+      ast::cast<ast::CommentStmt>(s))
     return;
   if (auto ss = ast::cast<ast::SuiteStmt>(s)) {
     for (auto &si : *ss)
@@ -507,10 +518,9 @@ JIT::JITResult JIT::jitClassNew(const std::string &className,
 
   try {
     auto *nativePtr = (*wrap)(args);
-    auto handle = nextJITClassHandle++;
-    jitClassObjects.emplace(handle,
-                            JITClassObject{className, nativeClassName, nativePtr});
-    return JITResult::success(reinterpret_cast<void *>(handle));
+    auto *instance =
+        new JITClassInstance(contextState, className, nativeClassName, nativePtr);
+    return JITResult::success(instance);
   } catch (const runtime::JITError &e) {
     auto err = handleJITError(e);
     auto errorInfo = llvm::toString(std::move(err));
@@ -518,19 +528,22 @@ JIT::JITResult JIT::jitClassNew(const std::string &className,
   }
 }
 
-JIT::JITResult JIT::jitClassCall(const std::string &className, uint64_t handle,
+JIT::JITResult JIT::jitClassCall(const std::string &className,
+                                 JITClassInstance *instance,
                                  const std::string &methodName,
                                  const std::vector<std::string> &types, void *args,
                                  bool debug) {
-  auto obj = jitClassObjects.find(handle);
-  if (obj == jitClassObjects.end())
-    return JITResult::error(fmt::format("invalid jitclass handle {}", handle));
-  if (obj->second.className != className)
+  if (!instance)
+    return JITResult::error("jitclass object has been released");
+  if (instance->className != className)
     return JITResult::error(
-        fmt::format("jitclass handle {} has type '{}', expected '{}'", handle,
-                    obj->second.className, className));
+        fmt::format("jitclass instance has type '{}', expected '{}'",
+                    instance->className, className));
+  // Reject calls after reset/destruction before looking up code in this engine.
+  if (!instance->contextState->alive.load() || instance->contextState != contextState)
+    return JITResult::error("jitclass object belongs to a stale JIT context");
 
-  auto key = buildJITClassKey("method", obj->second.nativeClassName, types, methodName);
+  auto key = buildJITClassKey("method", instance->nativeClassName, types, methodName);
   auto &cache = jitClassData->methodWrappers;
   auto it = cache.find(key);
   JITClassMethodFunc *wrap;
@@ -542,9 +555,8 @@ JIT::JITResult JIT::jitClassCall(const std::string &className, uint64_t handle,
   } else {
     auto idx = cache.size();
     auto wrapname = "__codon_jitclass_method_" + std::to_string(idx);
-    auto wrapper = buildJITClassMethodWrapper(obj->second.nativeClassName, methodName,
+    auto wrapper = buildJITClassMethodWrapper(instance->nativeClassName, methodName,
                                               wrapname, types);
-
     if (debug)
       fmt::print(stderr, "[codon::jit::jitClassCall] wrapper:\n{}-----\n", wrapper);
     if (auto err = compile(wrapper).takeError()) {
@@ -567,7 +579,7 @@ JIT::JITResult JIT::jitClassCall(const std::string &className, uint64_t handle,
   }
 
   try {
-    auto *ans = (*wrap)(obj->second.nativePtr, args);
+    auto *ans = (*wrap)(instance->nativePtr, args);
     return JITResult::success(ans);
   } catch (const runtime::JITError &e) {
     auto err = handleJITError(e);
@@ -576,22 +588,9 @@ JIT::JITResult JIT::jitClassCall(const std::string &className, uint64_t handle,
   }
 }
 
-JIT::JITResult JIT::jitClassRelease(const std::string &className, uint64_t handle,
-                                    bool debug) {
-  auto obj = jitClassObjects.find(handle);
-  if (obj == jitClassObjects.end())
-    return JITResult::success();
-
-  if (obj->second.className != className)
-    return JITResult::error(
-        fmt::format("jitclass handle {} has type '{}', expected '{}'", handle,
-                    obj->second.className, className));
-
-  if (debug)
-    fmt::print(stderr, "[codon::jit::jitClassRelease] release {} handle {}\n",
-               className, handle);
-
-  jitClassObjects.erase(obj);
+JIT::JITResult JIT::jitClassRelease(JITClassInstance *instance) {
+  // Deleting the control block also removes the RAII GC root.
+  delete instance;
   return JITResult::success();
 }
 
@@ -651,26 +650,26 @@ CJITResult jitclass_new(void *jit, char *class_name, char *native_class_name,
   return {result, message};
 }
 
-CJITResult jitclass_call(void *jit, char *class_name, uint64_t handle,
-                         char *method_name, char **types, size_t types_size, void *args,
-                         uint8_t debug) {
+CJITResult jitclass_call(void *jit, char *class_name, void *instance, char *method_name,
+                         char **types, size_t types_size, void *args, uint8_t debug) {
   std::vector<std::string> cppTypes;
   cppTypes.reserve(types_size);
   for (size_t i = 0; i < types_size; i++)
     cppTypes.emplace_back(types[i]);
-  auto t = ((codon::jit::JIT *)jit)
-               ->jitClassCall(std::string(class_name), handle, std::string(method_name),
-                              cppTypes, args, bool(debug));
+  auto t =
+      ((codon::jit::JIT *)jit)
+          ->jitClassCall(std::string(class_name),
+                         static_cast<codon::jit::JIT::JITClassInstance *>(instance),
+                         std::string(method_name), cppTypes, args, bool(debug));
   void *result = t.result;
   char *message =
       t.message.empty() ? nullptr : strndup(t.message.c_str(), t.message.size());
   return {result, message};
 }
 
-CJITResult jitclass_release(void *jit, char *class_name, uint64_t handle,
-                            uint8_t debug) {
-  auto t = ((codon::jit::JIT *)jit)
-               ->jitClassRelease(std::string(class_name), handle, bool(debug));
+CJITResult jitclass_release(void *instance) {
+  auto t = codon::jit::JIT::jitClassRelease(
+      static_cast<codon::jit::JIT::JITClassInstance *>(instance));
   void *result = t.result;
   char *message =
       t.message.empty() ? nullptr : strndup(t.message.c_str(), t.message.size());

--- a/codon/compiler/jit.cpp
+++ b/codon/compiler/jit.cpp
@@ -3,6 +3,7 @@
 #include "jit.h"
 
 #include <sstream>
+#include <utility>
 
 #include "codon/parser/common.h"
 #include "codon/parser/peg/peg.h"
@@ -18,6 +19,8 @@ namespace {
 typedef int MainFunc(int, char **);
 typedef void InputFunc();
 typedef void *PyWrapperFunc(void *);
+typedef void *JITClassNewFunc(void *);
+typedef void *JITClassMethodFunc(void *, void *);
 
 const std::string JIT_FILENAME = "<jit>";
 } // namespace
@@ -29,11 +32,34 @@ JIT::JIT(const std::string &argv0, const std::string &mode,
                                           /*isTest=*/false,
                                           /*pyNumerics=*/false, /*pyExtension=*/false)),
       engine(std::make_unique<Engine>()), pydata(std::make_unique<PythonData>()),
-      mode(mode), forgetful(false) {
+      jitClassData(std::make_unique<JITClassData>()), mode(mode), forgetful(false) {
   if (!stdlibRoot.empty())
     compiler->getCache()->fs->add_search_path(stdlibRoot);
   compiler->getLLVMVisitor()->setJIT(true);
 }
+
+JIT::JITClassRoot::JITClassRoot(void *ptr) : slot(std::make_unique<void *>(ptr)) {
+  seq_gc_add_roots(slot.get(), slot.get() + 1);
+}
+
+JIT::JITClassRoot::~JITClassRoot() {
+  if (slot)
+    seq_gc_remove_roots(slot.get(), slot.get() + 1);
+}
+
+JIT::JITClassRoot &JIT::JITClassRoot::operator=(JITClassRoot &&other) noexcept {
+  if (this != &other) {
+    if (slot)
+      seq_gc_remove_roots(slot.get(), slot.get() + 1);
+    slot = std::move(other.slot);
+  }
+  return *this;
+}
+
+JIT::JITClassObject::JITClassObject(std::string className, std::string nativeClassName,
+                                    void *nativePtr)
+    : className(std::move(className)), nativeClassName(std::move(nativeClassName)),
+      nativePtr(nativePtr), root(nativePtr) {}
 
 void collectExecutableStmts(ast::Stmt *s, ast::SuiteStmt *final) {
   if (cast<ast::FunctionStmt>(s) || cast<ast::ClassStmt>(s) ||
@@ -304,11 +330,79 @@ std::string buildPythonWrapper(const std::string &name, const std::string &wrapn
 
   return wrap.str();
 }
+
+std::string buildJITClassKey(const std::string &kind,
+                             const std::string &nativeClassName,
+                             const std::vector<std::string> &types,
+                             const std::string &methodName = "") {
+  std::stringstream key;
+  key << kind << "|" << nativeClassName;
+  if (!methodName.empty())
+    key << "|" << methodName;
+  for (const auto &t : types)
+    key << "|" << t;
+  return key.str();
+}
+
+std::string buildJITClassNewWrapper(const std::string &nativeClassName,
+                                    const std::string &wrapname,
+                                    const std::vector<std::string> &types) {
+  std::stringstream wrap;
+  wrap << "from internal.python import PyTuple_GetItem\n";
+  wrap << "@export\n";
+  wrap << "def " << wrapname << "(args: cobj) -> cobj:\n";
+  for (unsigned i = 0; i < types.size(); i++) {
+    wrap << "    a" << i << " = " << types[i] << ".__from_py__(PyTuple_GetItem(args, "
+         << i << "))\n";
+  }
+  wrap << "    obj = " << nativeClassName << "(";
+  for (unsigned i = 0; i < types.size(); i++) {
+    if (i > 0)
+      wrap << ", ";
+    wrap << "a" << i;
+  }
+  wrap << ")\n";
+  wrap << "    return obj.__raw__()\n";
+  return wrap.str();
+}
+
+std::string buildJITClassMethodWrapper(const std::string &nativeClassName,
+                                       const std::string &methodName,
+                                       const std::string &wrapname,
+                                       const std::vector<std::string> &types) {
+  std::stringstream wrap;
+  wrap << "from internal.python import PyTuple_GetItem\n";
+  wrap << "@export\n";
+  wrap << "def " << wrapname << "(self_obj: cobj, args: cobj) -> cobj:\n";
+  wrap << "    self = type._force_cast(self_obj, " << nativeClassName << ")\n";
+  for (unsigned i = 0; i < types.size(); i++) {
+    wrap << "    a" << i << " = " << types[i] << ".__from_py__(PyTuple_GetItem(args, "
+         << i << "))\n";
+  }
+  wrap << "    return self." << methodName << "(";
+  for (unsigned i = 0; i < types.size(); i++) {
+    if (i > 0)
+      wrap << ", ";
+    wrap << "a" << i;
+  }
+  wrap << ").__to_py__()\n";
+  return wrap.str();
+}
 } // namespace
 
 JIT::PythonData::PythonData() : cobj(nullptr), cache() {}
 
 ir::types::Type *JIT::PythonData::getCObjType(ir::Module *M) {
+  if (cobj)
+    return cobj;
+  cobj = M->getPointerType(M->getByteType());
+  return cobj;
+}
+
+JIT::JITClassData::JITClassData()
+    : cobj(nullptr), constructorWrappers(), methodWrappers() {}
+
+ir::types::Type *JIT::JITClassData::getCObjType(ir::Module *M) {
   if (cobj)
     return cobj;
   cobj = M->getPointerType(M->getByteType());
@@ -374,6 +468,133 @@ JIT::JITResult JIT::executePython(const std::string &name,
   }
 }
 
+JIT::JITResult JIT::jitClassNew(const std::string &className,
+                                const std::string &nativeClassName,
+                                const std::vector<std::string> &types, void *args,
+                                bool debug) {
+  auto key = buildJITClassKey("new", nativeClassName, types);
+  auto &cache = jitClassData->constructorWrappers;
+  auto it = cache.find(key);
+  JITClassNewFunc *wrap;
+
+  if (it != cache.end()) {
+    const std::string name = ir::LLVMVisitor::getNameForFunction(it->second);
+    auto func = llvm::cantFail(engine->lookup(name));
+    wrap = func.toPtr<JITClassNewFunc>();
+  } else {
+    auto idx = cache.size();
+    auto wrapname = "__codon_jitclass_new_" + std::to_string(idx);
+    auto wrapper = buildJITClassNewWrapper(nativeClassName, wrapname, types);
+    if (debug)
+      fmt::print(stderr, "[codon::jit::jitClassNew] wrapper:\n{}-----\n", wrapper);
+    if (auto err = compile(wrapper).takeError()) {
+      auto errorInfo = llvm::toString(std::move(err));
+      return JITResult::error(errorInfo);
+    }
+
+    auto *M = compiler->getModule();
+    auto *func = M->getOrRealizeFunc(wrapname, {jitClassData->getCObjType(M)});
+    seqassertn(func, "could not access jitclass constructor wrapper '{}'", wrapname);
+    cache.emplace(key, func);
+
+    auto result = address(func);
+    if (auto err = result.takeError()) {
+      auto errorInfo = llvm::toString(std::move(err));
+      return JITResult::error(errorInfo);
+    }
+    wrap = (JITClassNewFunc *)result.get();
+  }
+
+  try {
+    auto *nativePtr = (*wrap)(args);
+    auto handle = nextJITClassHandle++;
+    jitClassObjects.emplace(handle,
+                            JITClassObject{className, nativeClassName, nativePtr});
+    return JITResult::success(reinterpret_cast<void *>(handle));
+  } catch (const runtime::JITError &e) {
+    auto err = handleJITError(e);
+    auto errorInfo = llvm::toString(std::move(err));
+    return JITResult::error(errorInfo);
+  }
+}
+
+JIT::JITResult JIT::jitClassCall(const std::string &className, uint64_t handle,
+                                 const std::string &methodName,
+                                 const std::vector<std::string> &types, void *args,
+                                 bool debug) {
+  auto obj = jitClassObjects.find(handle);
+  if (obj == jitClassObjects.end())
+    return JITResult::error(fmt::format("invalid jitclass handle {}", handle));
+  if (obj->second.className != className)
+    return JITResult::error(
+        fmt::format("jitclass handle {} has type '{}', expected '{}'", handle,
+                    obj->second.className, className));
+
+  auto key = buildJITClassKey("method", obj->second.nativeClassName, types, methodName);
+  auto &cache = jitClassData->methodWrappers;
+  auto it = cache.find(key);
+  JITClassMethodFunc *wrap;
+
+  if (it != cache.end()) {
+    const std::string name = ir::LLVMVisitor::getNameForFunction(it->second);
+    auto func = llvm::cantFail(engine->lookup(name));
+    wrap = func.toPtr<JITClassMethodFunc>();
+  } else {
+    auto idx = cache.size();
+    auto wrapname = "__codon_jitclass_method_" + std::to_string(idx);
+    auto wrapper = buildJITClassMethodWrapper(obj->second.nativeClassName, methodName,
+                                              wrapname, types);
+
+    if (debug)
+      fmt::print(stderr, "[codon::jit::jitClassCall] wrapper:\n{}-----\n", wrapper);
+    if (auto err = compile(wrapper).takeError()) {
+      auto errorInfo = llvm::toString(std::move(err));
+      return JITResult::error(errorInfo);
+    }
+
+    auto *M = compiler->getModule();
+    auto *cobj = jitClassData->getCObjType(M);
+    auto *func = M->getOrRealizeFunc(wrapname, {cobj, cobj});
+    seqassertn(func, "could not access jitclass method wrapper '{}'", wrapname);
+    cache.emplace(key, func);
+
+    auto result = address(func);
+    if (auto err = result.takeError()) {
+      auto errorInfo = llvm::toString(std::move(err));
+      return JITResult::error(errorInfo);
+    }
+    wrap = (JITClassMethodFunc *)result.get();
+  }
+
+  try {
+    auto *ans = (*wrap)(obj->second.nativePtr, args);
+    return JITResult::success(ans);
+  } catch (const runtime::JITError &e) {
+    auto err = handleJITError(e);
+    auto errorInfo = llvm::toString(std::move(err));
+    return JITResult::error(errorInfo);
+  }
+}
+
+JIT::JITResult JIT::jitClassRelease(const std::string &className, uint64_t handle,
+                                    bool debug) {
+  auto obj = jitClassObjects.find(handle);
+  if (obj == jitClassObjects.end())
+    return JITResult::success();
+
+  if (obj->second.className != className)
+    return JITResult::error(
+        fmt::format("jitclass handle {} has type '{}', expected '{}'", handle,
+                    obj->second.className, className));
+
+  if (debug)
+    fmt::print(stderr, "[codon::jit::jitClassRelease] release {} handle {}\n",
+               className, handle);
+
+  jitClassObjects.erase(obj);
+  return JITResult::success();
+}
+
 } // namespace jit
 } // namespace codon
 
@@ -409,6 +630,47 @@ CJITResult jit_execute_safe(void *jit, char *code, char *file, int32_t line,
                             uint8_t debug) {
   auto t = ((codon::jit::JIT *)jit)
                ->executeSafe(std::string(code), std::string(file), line, bool(debug));
+  void *result = t.result;
+  char *message =
+      t.message.empty() ? nullptr : strndup(t.message.c_str(), t.message.size());
+  return {result, message};
+}
+
+CJITResult jitclass_new(void *jit, char *class_name, char *native_class_name,
+                        char **types, size_t types_size, void *args, uint8_t debug) {
+  std::vector<std::string> cppTypes;
+  cppTypes.reserve(types_size);
+  for (size_t i = 0; i < types_size; i++)
+    cppTypes.emplace_back(types[i]);
+  auto t = ((codon::jit::JIT *)jit)
+               ->jitClassNew(std::string(class_name), std::string(native_class_name),
+                             cppTypes, args, bool(debug));
+  void *result = t.result;
+  char *message =
+      t.message.empty() ? nullptr : strndup(t.message.c_str(), t.message.size());
+  return {result, message};
+}
+
+CJITResult jitclass_call(void *jit, char *class_name, uint64_t handle,
+                         char *method_name, char **types, size_t types_size, void *args,
+                         uint8_t debug) {
+  std::vector<std::string> cppTypes;
+  cppTypes.reserve(types_size);
+  for (size_t i = 0; i < types_size; i++)
+    cppTypes.emplace_back(types[i]);
+  auto t = ((codon::jit::JIT *)jit)
+               ->jitClassCall(std::string(class_name), handle, std::string(method_name),
+                              cppTypes, args, bool(debug));
+  void *result = t.result;
+  char *message =
+      t.message.empty() ? nullptr : strndup(t.message.c_str(), t.message.size());
+  return {result, message};
+}
+
+CJITResult jitclass_release(void *jit, char *class_name, uint64_t handle,
+                            uint8_t debug) {
+  auto t = ((codon::jit::JIT *)jit)
+               ->jitClassRelease(std::string(class_name), handle, bool(debug));
   void *result = t.result;
   char *message =
       t.message.empty() ? nullptr : strndup(t.message.c_str(), t.message.size());

--- a/codon/compiler/jit.h
+++ b/codon/compiler/jit.h
@@ -51,6 +51,42 @@ public:
     ir::types::Type *getCObjType(ir::Module *M);
   };
 
+  struct JITClassData {
+    ir::types::Type *cobj;
+    std::unordered_map<std::string, ir::Func *> constructorWrappers;
+    std::unordered_map<std::string, ir::Func *> methodWrappers;
+
+    JITClassData();
+    ir::types::Type *getCObjType(ir::Module *M);
+  };
+
+  struct JITClassRoot {
+    std::unique_ptr<void *> slot;
+
+    explicit JITClassRoot(void *ptr);
+    ~JITClassRoot();
+
+    JITClassRoot(JITClassRoot &&) noexcept = default;
+    JITClassRoot &operator=(JITClassRoot &&) noexcept;
+    JITClassRoot(const JITClassRoot &) = delete;
+    JITClassRoot &operator=(const JITClassRoot &) = delete;
+  };
+
+  struct JITClassObject {
+    std::string className;
+    std::string nativeClassName;
+    void *nativePtr;
+
+    JITClassRoot root;
+
+    JITClassObject(std::string className, std::string nativeClassName, void *nativePtr);
+
+    JITClassObject(JITClassObject &&) noexcept = default;
+    JITClassObject &operator=(JITClassObject &&) noexcept = default;
+    JITClassObject(const JITClassObject &) = delete;
+    JITClassObject &operator=(const JITClassObject &) = delete;
+  };
+
   struct JITResult {
     void *result;
     std::string message;
@@ -64,6 +100,9 @@ private:
   std::unique_ptr<Compiler> compiler;
   std::unique_ptr<Engine> engine;
   std::unique_ptr<PythonData> pydata;
+  std::unique_ptr<JITClassData> jitClassData;
+  std::unordered_map<uint64_t, JITClassObject> jitClassObjects;
+  uint64_t nextJITClassHandle = 1;
   std::string mode;
   bool forgetful = false;
 
@@ -99,6 +138,13 @@ public:
                           bool debug);
   JITResult executeSafe(const std::string &code, const std::string &file, int line,
                         bool debug);
+  JITResult jitClassNew(const std::string &className,
+                        const std::string &nativeClassName,
+                        const std::vector<std::string> &types, void *args, bool debug);
+  JITResult jitClassCall(const std::string &className, uint64_t handle,
+                         const std::string &methodName,
+                         const std::vector<std::string> &types, void *args, bool debug);
+  JITResult jitClassRelease(const std::string &className, uint64_t handle, bool debug);
 
   // Errors
   llvm::Error handleJITError(const runtime::JITError &e);

--- a/codon/compiler/jit.h
+++ b/codon/compiler/jit.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -53,6 +54,7 @@ public:
 
   struct JITClassData {
     ir::types::Type *cobj;
+    // Cache generated wrappers by native class, method name, and argument types.
     std::unordered_map<std::string, ir::Func *> constructorWrappers;
     std::unordered_map<std::string, ir::Func *> methodWrappers;
 
@@ -60,6 +62,14 @@ public:
     ir::types::Type *getCObjType(ir::Module *M);
   };
 
+  // Shared liveness token used by native instances to detect stale JIT contexts.
+  struct JITContextState {
+    std::atomic<bool> alive;
+
+    JITContextState() : alive(true) {}
+  };
+
+  // RAII root for Codon GC-managed objects exposed through Python-owned instances.
   struct JITClassRoot {
     std::unique_ptr<void *> slot;
 
@@ -72,19 +82,24 @@ public:
     JITClassRoot &operator=(const JITClassRoot &) = delete;
   };
 
-  struct JITClassObject {
+  // Opaque native control block owned by the Cython extension type.
+  struct JITClassInstance {
+    std::shared_ptr<JITContextState> contextState;
     std::string className;
     std::string nativeClassName;
     void *nativePtr;
 
+    // Keeps the underlying Codon object alive while Python can still reach it.
     JITClassRoot root;
 
-    JITClassObject(std::string className, std::string nativeClassName, void *nativePtr);
+    JITClassInstance(std::shared_ptr<JITContextState> contextState,
+                     std::string className, std::string nativeClassName,
+                     void *nativePtr);
 
-    JITClassObject(JITClassObject &&) noexcept = default;
-    JITClassObject &operator=(JITClassObject &&) noexcept = default;
-    JITClassObject(const JITClassObject &) = delete;
-    JITClassObject &operator=(const JITClassObject &) = delete;
+    JITClassInstance(JITClassInstance &&) noexcept = default;
+    JITClassInstance &operator=(JITClassInstance &&) noexcept = default;
+    JITClassInstance(const JITClassInstance &) = delete;
+    JITClassInstance &operator=(const JITClassInstance &) = delete;
   };
 
   struct JITResult {
@@ -101,14 +116,14 @@ private:
   std::unique_ptr<Engine> engine;
   std::unique_ptr<PythonData> pydata;
   std::unique_ptr<JITClassData> jitClassData;
-  std::unordered_map<uint64_t, JITClassObject> jitClassObjects;
-  uint64_t nextJITClassHandle = 1;
+  std::shared_ptr<JITContextState> contextState;
   std::string mode;
   bool forgetful = false;
 
 public:
   explicit JIT(const std::string &argv0, const std::string &mode = "",
                const std::string &stdlibRoot = "");
+  ~JIT();
 
   Compiler *getCompiler() const { return compiler.get(); }
   Engine *getEngine() const { return engine.get(); }
@@ -138,13 +153,16 @@ public:
                           bool debug);
   JITResult executeSafe(const std::string &code, const std::string &file, int line,
                         bool debug);
+  // Create a native jitclass object and return its opaque control block.
   JITResult jitClassNew(const std::string &className,
                         const std::string &nativeClassName,
                         const std::vector<std::string> &types, void *args, bool debug);
-  JITResult jitClassCall(const std::string &className, uint64_t handle,
+  // Dispatch a method or generated field accessor on an existing native instance.
+  JITResult jitClassCall(const std::string &className, JITClassInstance *instance,
                          const std::string &methodName,
                          const std::vector<std::string> &types, void *args, bool debug);
-  JITResult jitClassRelease(const std::string &className, uint64_t handle, bool debug);
+  // Release an opaque jitclass control block; safe to call without a live JIT.
+  static JITResult jitClassRelease(JITClassInstance *instance);
 
   // Errors
   llvm::Error handleJITError(const runtime::JITError &e);

--- a/codon/compiler/jit_extern.h
+++ b/codon/compiler/jit_extern.h
@@ -24,6 +24,17 @@ struct CJITResult jit_execute_python(void *jit, char *name, char **types,
 struct CJITResult jit_execute_safe(void *jit, char *code, char *file, int32_t line,
                                    uint8_t debug);
 
+struct CJITResult jitclass_new(void *jit, char *class_name, char *native_class_name,
+                               char **types, size_t types_size, void *args,
+                               uint8_t debug);
+
+struct CJITResult jitclass_call(void *jit, char *class_name, uint64_t handle,
+                                char *method_name, char **types, size_t types_size,
+                                void *args, uint8_t debug);
+
+struct CJITResult jitclass_release(void *jit, char *class_name, uint64_t handle,
+                                   uint8_t debug);
+
 char *get_jit_library();
 
 #ifdef __cplusplus

--- a/codon/compiler/jit_extern.h
+++ b/codon/compiler/jit_extern.h
@@ -28,12 +28,11 @@ struct CJITResult jitclass_new(void *jit, char *class_name, char *native_class_n
                                char **types, size_t types_size, void *args,
                                uint8_t debug);
 
-struct CJITResult jitclass_call(void *jit, char *class_name, uint64_t handle,
+struct CJITResult jitclass_call(void *jit, char *class_name, void *instance,
                                 char *method_name, char **types, size_t types_size,
                                 void *args, uint8_t debug);
 
-struct CJITResult jitclass_release(void *jit, char *class_name, uint64_t handle,
-                                   uint8_t debug);
+struct CJITResult jitclass_release(void *instance);
 
 char *get_jit_library();
 

--- a/jit/codon/__init__.py
+++ b/jit/codon/__init__.py
@@ -1,9 +1,17 @@
 # Copyright (C) 2022-2026 Exaloop Inc. <https://exaloop.io>
 
 __all__ = [
-    "jit", "convert", "JITError", "JITWrapper", "_jit_register_fn", "_jit"
+    "jit",
+    "convert",
+    "jitclass",
+    "JITError",
+    "JITWrapper",
+    "_jit_register_fn",
+    "_jit",
 ]
 
 from .decorator import jit, convert, execute, JITError, JITWrapper, _jit_register_fn, _jit_callback_fn, _jit
+
+from .jitclass import jitclass
 
 __codon__ = False

--- a/jit/codon/decorator.py
+++ b/jit/codon/decorator.py
@@ -146,6 +146,59 @@ def _codon_type(arg, **kwargs):
 def _codon_types(args, **kwargs):
     return tuple(_codon_type(arg, **kwargs) for arg in args)
 
+def bind_args(func, args, kwargs, drop_self=False):
+    bound_self = None
+    if inspect.ismethod(func) and func.__self__ is not None:
+        bound_self = func.__self__
+        func = func.__func__
+        args = (bound_self, *args)
+    sig = inspect.signature(func)
+    bound_args = sig.bind(*args, **kwargs)
+    bound_args.apply_defaults()
+    names = list(sig.parameters)
+    if drop_self and names and names[0] == "self":
+        names = names[1:]
+    return tuple(bound_args.arguments[p] for p in names)
+
+class JITCallable:
+    def __init__(self, py_func, obj_name, module, debug=0, sample_size=5, pyvars=None):
+        self.py_func = py_func
+        self.obj_name = obj_name
+        self.module = module
+        self.debug = debug
+        self.sample_size = sample_size
+        self.pyvars = pyvars or []
+    def codon_types(self, args):
+        return _codon_types(args, debug=self.debug, sample_size=self.sample_size)
+    def bind_args(self, args, kwargs, drop_self=False):
+        if self.py_func is not None:
+            return bind_args(self.py_func, args, kwargs, drop_self)
+        return (*args, *kwargs.values())
+    def reset_on_jit_error(self, fn):
+        try:
+            return fn()
+        except JITError:
+            _reset_jit()
+            raise
+    def __call__(self, *args, **kwargs):
+        def run():
+            bound_args = self.bind_args(args, kwargs)
+            types = self.codon_types(bound_args)
+            if self.debug > 0:
+                print(
+                    "[python] {}({})".format(self.obj_name, list(types)),
+                    file=sys.stderr,
+                )
+            return _jit.run_wrapper(
+                self.obj_name,
+                list(types),
+                self.module,
+                list(self.pyvars),
+                bound_args,
+                int(self.debug > 0),
+            )
+        return self.reset_on_jit_error(run)
+
 def _reset_jit():
     global _jit
     _jit = JITWrapper()
@@ -258,31 +311,16 @@ def _jit_callback_fn(fn,
                      pyvars=None,
                      *args,
                      **kwargs):
-    if fn is not None:
-        sig = inspect.signature(fn)
-        bound_args = sig.bind(*args, **kwargs)
-        bound_args.apply_defaults()
-        args = tuple(bound_args.arguments[param] for param in sig.parameters)
-    else:
-        args = (*args, *kwargs.values())
-
-    try:
-        types = _codon_types(args, debug=debug, sample_size=sample_size)
-        if debug > 0:
-            print("[python] {}({})".format(obj_name, list(types)), file=sys.stderr)
-        return _jit.run_wrapper(
-            obj_name, list(types), module, list(pyvars), args, int(debug > 0)
-        )
-    except JITError:
-        _reset_jit()
-        raise
+    return JITCallable(fn, obj_name, module, debug, sample_size, pyvars)(
+        *args, **kwargs
+    )
 
 def _jit_str_fn(fstr, debug=0, sample_size=5, pyvars=None):
     obj_name = _jit_register_fn(fstr, pyvars, debug)
+    jit_func = JITCallable(None, obj_name, "__main__", debug, sample_size, pyvars)
 
     def wrapped(*args, **kwargs):
-        return _jit_callback_fn(None, obj_name, "__main__", debug, sample_size,
-                                pyvars, *args, **kwargs)
+        return jit_func(*args, **kwargs)
 
     return wrapped
 
@@ -304,11 +342,11 @@ def jit(fn=None, debug=0, sample_size=5, pyvars=None):
 
     def _decorate(f):
         obj_name = _jit_register_fn(f, pyvars, debug)
+        jit_func = JITCallable(f, obj_name, f.__module__, debug, sample_size, pyvars)
 
         @functools.wraps(f)
         def wrapped(*args, **kwargs):
-            return _jit_callback_fn(f, obj_name, f.__module__, debug,
-                                    sample_size, pyvars, *args, **kwargs)
+            return jit_func(*args, **kwargs)
 
         return wrapped
 

--- a/jit/codon/jit.pxd
+++ b/jit/codon/jit.pxd
@@ -1,6 +1,7 @@
 # Copyright (C) 2022-2025 Exaloop Inc. <https://exaloop.io>
 
-from libc.stdint cimport int32_t, uint8_t
+from libc.stddef cimport size_t
+from libc.stdint cimport int32_t, uint8_t, uint64_t
 
 cdef extern from "codon/compiler/jit_extern.h":
     cdef struct CJITResult:
@@ -19,4 +20,15 @@ cdef extern from "codon/compiler/jit_extern.h":
         void *jit, char *name, char **types, size_t types_size,
         char *pyModule, char **py_vars, size_t py_vars_size,
         void *arg, uint8_t debug
+    )
+    cdef CJITResult c_jitclass_new "jitclass_new"(
+        void *jit, char *class_name, char *native_class_name,
+        char **types, size_t types_size, void *args, uint8_t debug
+    )
+    cdef CJITResult c_jitclass_call "jitclass_call"(
+        void *jit, char *class_name, uint64_t handle, char *method_name,
+        char **types, size_t types_size, void *args, uint8_t debug
+    )
+    cdef CJITResult c_jitclass_release "jitclass_release"(
+        void *jit, char *class_name, uint64_t handle, uint8_t debug
     )

--- a/jit/codon/jit.pxd
+++ b/jit/codon/jit.pxd
@@ -1,7 +1,7 @@
 # Copyright (C) 2022-2025 Exaloop Inc. <https://exaloop.io>
 
 from libc.stddef cimport size_t
-from libc.stdint cimport int32_t, uint8_t, uint64_t
+from libc.stdint cimport int32_t, uint8_t
 
 cdef extern from "codon/compiler/jit_extern.h":
     cdef struct CJITResult:
@@ -26,9 +26,9 @@ cdef extern from "codon/compiler/jit_extern.h":
         char **types, size_t types_size, void *args, uint8_t debug
     )
     cdef CJITResult c_jitclass_call "jitclass_call"(
-        void *jit, char *class_name, uint64_t handle, char *method_name,
+        void *jit, char *class_name, void *instance, char *method_name,
         char **types, size_t types_size, void *args, uint8_t debug
     )
     cdef CJITResult c_jitclass_release "jitclass_release"(
-        void *jit, char *class_name, uint64_t handle, uint8_t debug
+        void *instance
     )

--- a/jit/codon/jit.pyx
+++ b/jit/codon/jit.pyx
@@ -9,7 +9,7 @@ cimport codon.jit
 from libc.stddef cimport size_t
 from libc.stdlib cimport malloc, calloc, free
 from libc.string cimport strcpy
-from libc.stdint cimport int32_t, uint8_t, uint64_t
+from libc.stdint cimport int32_t, uint8_t
 
 
 class JITError(Exception):
@@ -25,6 +25,95 @@ cdef str get_free_str(char *s):
         free(s)
 
 
+cdef class JITClassInstanceHandle:
+    """Owns the opaque native jitclass control block returned by C++."""
+    cdef void* instance
+
+    def __cinit__(self):
+        self.instance = NULL
+
+    cdef void set_instance(self, void* instance):
+        self.instance = instance
+
+    cdef void* get_instance(self):
+        return self.instance
+
+    cdef void* require_instance(self) except NULL:
+        if self.instance is NULL:
+            raise JITError("jitclass object has been released")
+        return self.instance
+
+    def close(self):
+        cdef codon.jit.CJITResult result
+        cdef void* instance
+        if self.instance is NULL:
+            return
+
+        # Invalidate first so re-entrant cleanup cannot release the same block twice.
+        instance = self.instance
+        self.instance = NULL
+        result = codon.jit.c_jitclass_release(instance)
+        if result.error is not NULL:
+            msg = get_free_str(result.error)
+            raise JITError(msg)
+
+    @property
+    def closed(self):
+        return self.instance is NULL
+
+    cdef object _call_with_jit(self, void* jit, str class_name, str method_name,
+                              list types, args, debug):
+        cdef codon.jit.CJITResult result
+        cdef size_t types_size = len(types)
+        cdef size_t alloc_size = types_size if types_size > 0 else 1
+        cdef char** c_types
+        cdef void* instance = self.require_instance()
+        cdef bytes encoded
+        cdef str msg
+        if jit is NULL:
+            raise JITError("JIT context has been released")
+
+        c_types = <char**>calloc(alloc_size, sizeof(char*))
+        if not c_types:
+            raise JITError("Cython allocation failed")
+        try:
+            for i, s in enumerate(types):
+                encoded = s.encode('utf-8')
+                c_types[i] = <char*>malloc(len(encoded) + 1)
+                if not c_types[i]:
+                    raise JITError("Cython allocation failed")
+                strcpy(c_types[i], encoded)
+            result = codon.jit.c_jitclass_call(
+                jit, class_name.encode('utf-8'), instance,
+                method_name.encode('utf-8'), c_types, types_size,
+                <void *>args, <uint8_t>debug
+            )
+            if result.error is NULL:
+                return <object>result.result
+            else:
+                msg = get_free_str(result.error)
+                raise JITError(msg)
+        finally:
+            for i in range(len(types)):
+                free(c_types[i])
+            free(c_types)
+
+    def call_with_jit(self, JITWrapper jit_wrapper, class_name: str, method_name: str,
+                      types: list[str], args, debug) -> object:
+        """Call a native method through the current JIT wrapper."""
+        if jit_wrapper is None:
+            raise JITError("JIT context has been released")
+        return self._call_with_jit(jit_wrapper.jit, class_name, method_name, types, args, debug)
+
+    def __dealloc__(self):
+        cdef void* instance
+        if self.instance is not NULL:
+            # Final safety net for paths that did not call close() explicitly.
+            instance = self.instance
+            self.instance = NULL
+            codon.jit.c_jitclass_release(instance)
+
+
 cdef class JITWrapper:
     cdef void* jit
 
@@ -32,7 +121,9 @@ cdef class JITWrapper:
         self.jit = codon.jit.jit_init(b"codon jit")
 
     def __dealloc__(self):
-        codon.jit.jit_exit(self.jit)
+        if self.jit is not NULL:
+            codon.jit.jit_exit(self.jit)
+            self.jit = NULL
 
     def execute(self, code: str, filename: str, fileno: int, debug) -> str:
         result = codon.jit.jit_execute_safe(
@@ -79,10 +170,12 @@ cdef class JITWrapper:
             free(c_pyvars)
 
     def jitclass_new(self, class_name: str, native_class_name: str,
-                     types: list[str], args, debug) -> int:
+                     types: list[str], args, debug) -> JITClassInstanceHandle:
+        """Create a native jitclass instance and wrap it in a Python-owned handle."""
         cdef size_t types_size = len(types)
         cdef size_t alloc_size = types_size if types_size > 0 else 1
         cdef char** c_types = <char**>calloc(alloc_size, sizeof(char*))
+        cdef JITClassInstanceHandle handle
         if not c_types:
             raise JITError("Cython allocation failed")
         try:
@@ -96,7 +189,9 @@ cdef class JITWrapper:
                 c_types, types_size, <void *>args, <uint8_t>debug
             )
             if result.error is NULL:
-                return <uint64_t>result.result
+                handle = JITClassInstanceHandle()
+                handle.set_instance(result.result)
+                return handle
             else:
                 msg = get_free_str(result.error)
                 raise JITError(msg)
@@ -104,42 +199,6 @@ cdef class JITWrapper:
             for i in range(len(types)):
                 free(c_types[i])
             free(c_types)
-
-    def jitclass_call(self, class_name: str, handle: int, method_name: str,
-                      types: list[str], args, debug) -> object:
-        cdef size_t types_size = len(types)
-        cdef size_t alloc_size = types_size if types_size > 0 else 1
-        cdef char** c_types = <char**>calloc(alloc_size, sizeof(char*))
-        if not c_types:
-            raise JITError("Cython allocation failed")
-        try:
-            for i, s in enumerate(types):
-                bytes = s.encode('utf-8')
-                c_types[i] = <char*>malloc(len(bytes) + 1)
-                strcpy(c_types[i], bytes)
-            result = codon.jit.c_jitclass_call(
-                self.jit, class_name.encode('utf-8'), <uint64_t>handle,
-                method_name.encode('utf-8'), c_types, types_size,
-                <void *>args, <uint8_t>debug
-            )
-            if result.error is NULL:
-                return <object>result.result
-            else:
-                msg = get_free_str(result.error)
-                raise JITError(msg)
-        finally:
-            for i in range(len(types)):
-                free(c_types[i])
-            free(c_types)
-
-    def jitclass_release(self, class_name: str, handle: int, debug) -> None:
-        result = codon.jit.c_jitclass_release(
-            self.jit, class_name.encode('utf-8'), <uint64_t>handle, <uint8_t>debug
-        )
-        if result.error is not NULL:
-            msg = get_free_str(result.error)
-            raise JITError(msg)
-
 
 def codon_library():
     cdef char* c = codon.jit.get_jit_library()

--- a/jit/codon/jit.pyx
+++ b/jit/codon/jit.pyx
@@ -6,9 +6,10 @@
 # cython: c_string_encoding=utf8
 
 cimport codon.jit
+from libc.stddef cimport size_t
 from libc.stdlib cimport malloc, calloc, free
 from libc.string cimport strcpy
-from libc.stdint cimport int32_t, uint8_t
+from libc.stdint cimport int32_t, uint8_t, uint64_t
 
 
 class JITError(Exception):
@@ -43,7 +44,8 @@ cdef class JITWrapper:
             msg = get_free_str(result.error)
             raise JITError(msg)
 
-    def run_wrapper(self, name: str, types: list[str], module: str, pyvars: list[str], args, debug) -> object:
+    def run_wrapper(self, name: str, types: list[str], module: str,
+                    pyvars: list[str], args, debug) -> object:
         cdef char** c_types = <char**>calloc(len(types), sizeof(char*))
         cdef char** c_pyvars = <char**>calloc(len(pyvars), sizeof(char*))
         if not c_types or not c_pyvars:
@@ -75,6 +77,68 @@ cdef class JITWrapper:
             for i in range(len(pyvars)):
                 free(c_pyvars[i])
             free(c_pyvars)
+
+    def jitclass_new(self, class_name: str, native_class_name: str,
+                     types: list[str], args, debug) -> int:
+        cdef size_t types_size = len(types)
+        cdef size_t alloc_size = types_size if types_size > 0 else 1
+        cdef char** c_types = <char**>calloc(alloc_size, sizeof(char*))
+        if not c_types:
+            raise JITError("Cython allocation failed")
+        try:
+            for i, s in enumerate(types):
+                bytes = s.encode('utf-8')
+                c_types[i] = <char*>malloc(len(bytes) + 1)
+                strcpy(c_types[i], bytes)
+            result = codon.jit.c_jitclass_new(
+                self.jit, class_name.encode('utf-8'),
+                native_class_name.encode('utf-8'),
+                c_types, types_size, <void *>args, <uint8_t>debug
+            )
+            if result.error is NULL:
+                return <uint64_t>result.result
+            else:
+                msg = get_free_str(result.error)
+                raise JITError(msg)
+        finally:
+            for i in range(len(types)):
+                free(c_types[i])
+            free(c_types)
+
+    def jitclass_call(self, class_name: str, handle: int, method_name: str,
+                      types: list[str], args, debug) -> object:
+        cdef size_t types_size = len(types)
+        cdef size_t alloc_size = types_size if types_size > 0 else 1
+        cdef char** c_types = <char**>calloc(alloc_size, sizeof(char*))
+        if not c_types:
+            raise JITError("Cython allocation failed")
+        try:
+            for i, s in enumerate(types):
+                bytes = s.encode('utf-8')
+                c_types[i] = <char*>malloc(len(bytes) + 1)
+                strcpy(c_types[i], bytes)
+            result = codon.jit.c_jitclass_call(
+                self.jit, class_name.encode('utf-8'), <uint64_t>handle,
+                method_name.encode('utf-8'), c_types, types_size,
+                <void *>args, <uint8_t>debug
+            )
+            if result.error is NULL:
+                return <object>result.result
+            else:
+                msg = get_free_str(result.error)
+                raise JITError(msg)
+        finally:
+            for i in range(len(types)):
+                free(c_types[i])
+            free(c_types)
+
+    def jitclass_release(self, class_name: str, handle: int, debug) -> None:
+        result = codon.jit.c_jitclass_release(
+            self.jit, class_name.encode('utf-8'), <uint64_t>handle, <uint8_t>debug
+        )
+        if result.error is not NULL:
+            msg = get_free_str(result.error)
+            raise JITError(msg)
 
 
 def codon_library():

--- a/jit/codon/jitclass.py
+++ b/jit/codon/jitclass.py
@@ -12,10 +12,10 @@ import astunparse
 
 from typing import Any
 
+from . import decorator as _decorator
 from .decorator import (
     JITCallable,
     JITError,
-    _jit,
     _reset_jit,
     debug_override,
 )
@@ -26,6 +26,8 @@ def _jitclass_default_init(self):
 
 
 class JITClassMeta:
+    """Static metadata extracted from the original Python class."""
+
     def __init__(self, py_cls, native_class_name):
         self.py_cls = py_cls
         self.class_name = py_cls.__name__
@@ -52,6 +54,8 @@ class JITClassMeta:
 
 
 class JITClassASTTransformer(ast.NodeTransformer):
+    """Validate a jitclass and rewrite it into the native Codon class body."""
+
     def __init__(self, meta: JITClassMeta):
         self.meta = meta
         self.has_fields = False
@@ -74,6 +78,7 @@ class JITClassASTTransformer(ast.NodeTransformer):
         node.decorator_list = []
         node.name = self.meta.native_class_name
         node.body = [self._visit_class_stmt(stmt) for stmt in node.body]
+        # Field descriptors dispatch through generated native getter/setter methods.
         node.body.extend(self._make_field_accessors())
         return node
 
@@ -179,33 +184,25 @@ class JITClassASTTransformer(ast.NodeTransformer):
 
 
 class JITClassProxy:
+    """Holds the native handle for one Python-visible jitclass instance."""
+
     def __init__(self, meta: JITClassMeta, native_cls, handle, debug=0):
         self.meta = meta
         self.native_cls = native_cls
         self.handle = handle
         self.debug = debug
-        self.closed = False
 
-    def ensure_alive(self):
-        if self.closed:
-            raise JITError("jitclass object has been released")
+    @property
+    def closed(self):
+        return self.handle is None or self.handle.closed
 
     def close(self):
-        if self.closed:
-            return
-
-        handle = self.handle
-        self.closed = True
-        self.handle = 0
-
-        _jit.jitclass_release(
-            self.meta.class_name,
-            handle,
-            int(self.debug > 0),
-        )
+        if self.handle is not None:
+            self.handle.close()
 
 
 def _close_jitclass_proxy(proxy, suppress=False):
+    """Close a proxy from weakref finalization without relying on __del__."""
     try:
         proxy.close()
     except Exception:
@@ -214,10 +211,12 @@ def _close_jitclass_proxy(proxy, suppress=False):
 
 
 class JITNativeClass:
+    """Base class for Python objects backed by native jitclass instances."""
+
     def __init__(self, *args, **kwargs):
         proxy = type(self).__codon_constructor__(self, *args, **kwargs)
         object.__setattr__(self, "__codon_jitclass_proxy__", proxy)
-        object.__setattr__(self, "__codon_handle__", proxy.handle)
+        # weakref.finalize avoids __del__ cycles while ensuring native cleanup.
         object.__setattr__(
             self,
             "__codon_finalizer__",
@@ -228,17 +227,10 @@ class JITNativeClass:
         proxy = getattr(self, "__codon_jitclass_proxy__", None)
         if proxy is not None:
             proxy.close()
-            object.__setattr__(self, "__codon_handle__", proxy.handle)
 
         finalizer = getattr(self, "__codon_finalizer__", None)
         if finalizer is not None:
             finalizer.detach()
-
-    def __del__(self):
-        try:
-            self.close()
-        except Exception:
-            pass
 
     def __enter__(self):
         return self
@@ -262,6 +254,8 @@ class JITNativeClass:
 
 
 class JITClassCtor(JITCallable):
+    """Descriptor-like constructor that materializes the native instance."""
+
     def __init__(self, meta: JITClassMeta, init: Any, debug=0, sample_size=5):
         super().__init__(init, init.__name__, init.__module__, debug, sample_size)
         self.meta = meta
@@ -276,7 +270,7 @@ class JITClassCtor(JITCallable):
                     f"[python] {self.meta.class_name}.{self.py_func.__name__}({bound_args})",
                     file=sys.stderr,
                 )
-            handle = _jit.jitclass_new(
+            handle = _decorator._jit.jitclass_new(
                 self.meta.class_name,
                 self.meta.native_class_name,
                 list(arg_types),
@@ -289,6 +283,8 @@ class JITClassCtor(JITCallable):
 
 
 class JITMethod(JITCallable):
+    """Method descriptor that dispatches calls to the native jitclass object."""
+
     def __init__(self, meta: JITClassMeta, method: Any, debug=0, sample_size=5):
         super().__init__(method, method.__name__, method.__module__, debug, sample_size)
         self.meta = meta
@@ -306,7 +302,6 @@ class JITMethod(JITCallable):
     def __call__(self, obj, *args, **kwargs):
         def run():
             proxy = obj.__codon_jitclass_proxy__
-            proxy.ensure_alive()
             bound_args = self.bind_args((obj,) + args, kwargs, drop_self=True)
             arg_types = self.codon_types(bound_args)
 
@@ -315,9 +310,9 @@ class JITMethod(JITCallable):
                     f"[python] {self.meta.class_name}.{self.py_func.__name__}({bound_args})",
                     file=sys.stderr,
                 )
-            return _jit.jitclass_call(
+            return proxy.handle.call_with_jit(
+                _decorator._jit,
                 self.meta.class_name,
-                proxy.handle,
                 self.py_func.__name__,
                 list(arg_types),
                 bound_args,
@@ -328,6 +323,8 @@ class JITMethod(JITCallable):
 
 
 class JITField(JITCallable):
+    """Field descriptor backed by generated native getter and setter wrappers."""
+
     def __init__(self, meta: JITClassMeta, field_name: str, debug=0, sample_size=5):
         super().__init__(None, field_name, meta.py_cls.__module__, debug, sample_size)
         self.meta = meta
@@ -339,15 +336,14 @@ class JITField(JITCallable):
 
         def run():
             proxy = obj.__codon_jitclass_proxy__
-            proxy.ensure_alive()
             if self.debug == 2:
                 print(
                     f"[python] {self.meta.class_name}.{self.field_name}",
                     file=sys.stderr,
                 )
-            return _jit.jitclass_call(
+            return proxy.handle.call_with_jit(
+                _decorator._jit,
                 self.meta.class_name,
-                proxy.handle,
                 _field_getter_name(self.field_name),
                 [],
                 (),
@@ -359,7 +355,6 @@ class JITField(JITCallable):
     def __set__(self, obj, value):
         def run():
             proxy = obj.__codon_jitclass_proxy__
-            proxy.ensure_alive()
             bound_args = (value,)
             arg_types = self.codon_types(bound_args)
             if self.debug == 2:
@@ -367,9 +362,9 @@ class JITField(JITCallable):
                     f"[python] {self.meta.class_name}.{self.field_name} = {value!r}",
                     file=sys.stderr,
                 )
-            _jit.jitclass_call(
+            proxy.handle.call_with_jit(
+                _decorator._jit,
                 self.meta.class_name,
-                proxy.handle,
                 _field_setter_name(self.field_name),
                 list(arg_types),
                 bound_args,
@@ -380,6 +375,8 @@ class JITField(JITCallable):
 
 
 class JITClassCreator:
+    """Compiles the native class and builds the Python proxy type."""
+
     def __init__(self, py_cls, debug=0, sample_size=5):
         if not inspect.isclass(py_cls):
             raise TypeError("jitclass expects a class, got " + type(py_cls).__name__)
@@ -422,7 +419,7 @@ class JITClassCreator:
         if self.debug == 2:
             print(f"[jit_debug] execute:\n{class_code}", file=sys.stderr)
         try:
-            _jit.execute(
+            _decorator._jit.execute(
                 class_code, self.meta.source_file, 1, int(self.debug > 0)
             )
         except JITError:

--- a/jit/codon/jitclass.py
+++ b/jit/codon/jitclass.py
@@ -1,0 +1,482 @@
+# Copyright (C) 2022-2026 Exaloop Inc. <https://exaloop.io>
+from __future__ import annotations
+
+import ast
+import functools
+import inspect
+import re
+import sys
+import textwrap
+import weakref
+import astunparse
+
+from typing import Any
+
+from .decorator import (
+    JITCallable,
+    JITError,
+    _jit,
+    _reset_jit,
+    debug_override,
+)
+
+
+def _jitclass_default_init(self):
+    pass
+
+
+class JITClassMeta:
+    def __init__(self, py_cls, native_class_name):
+        self.py_cls = py_cls
+        self.class_name = py_cls.__name__
+        self.native_class_name = native_class_name
+        self.source_file = inspect.getsourcefile(py_cls) or "<internal>"
+        self.init = None
+        self.methods = {}
+        self.fields = {}
+        self.has_fields = False
+
+    def bind_init(self, allow_default=False):
+        init = self.py_cls.__dict__.get("__init__")
+        if init is None:
+            if not allow_default:
+                raise JITError("jitclass requires an __init__ method")
+            init = _jitclass_default_init
+        self.init = init
+
+    def bind_methods(self, method_names):
+        self.methods = {name: self.py_cls.__dict__[name] for name in method_names}
+
+    def bind_fields(self, fields):
+        self.fields = dict(fields)
+
+
+class JITClassASTTransformer(ast.NodeTransformer):
+    def __init__(self, meta: JITClassMeta):
+        self.meta = meta
+        self.has_fields = False
+        self.has_init = False
+        self.fields = []
+        self.method_names = []
+
+    def visit_Module(self, node):
+        class_nodes = [stmt for stmt in node.body if isinstance(stmt, ast.ClassDef)]
+        if not class_nodes:
+            raise JITError("jitclass expects a class definition")
+
+        node.body = [self.visit(class_nodes[0])]
+        return node
+
+    def visit_ClassDef(self, node):
+        if node.bases or node.keywords:
+            raise JITError("jitclass does not support inheritance")
+
+        node.decorator_list = []
+        node.name = self.meta.native_class_name
+        node.body = [self._visit_class_stmt(stmt) for stmt in node.body]
+        node.body.extend(self._make_field_accessors())
+        return node
+
+    def _visit_class_stmt(self, stmt):
+        if isinstance(stmt, ast.AnnAssign):
+            if not isinstance(stmt.target, ast.Name):
+                raise JITError("jitclass fields must be simple names")
+            if stmt.value is not None:
+                raise JITError("jitclass fields cannot have default values")
+            self.fields.append((stmt.target.id, stmt.annotation))
+            self.has_fields = True
+            return stmt
+
+        if isinstance(stmt, ast.FunctionDef):
+            if stmt.name.startswith("_codon_jitclass_"):
+                raise JITError(
+                    "method name '{}' is reserved for jitclass".format(stmt.name)
+                )
+            if stmt.decorator_list:
+                raise JITError("jitclass methods cannot have decorators")
+            _validate_method_args(stmt.args, stmt.name)
+            if stmt.name == "__init__":
+                self.has_init = True
+            else:
+                self.method_names.append(stmt.name)
+            return stmt
+
+        if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Constant):
+            return stmt
+
+        if isinstance(stmt, ast.Pass):
+            return stmt
+
+        raise JITError(
+            "unsupported statement in jitclass '{}'".format(self.meta.class_name)
+        )
+
+    def _make_field_accessors(self):
+        accessors = []
+        for field_name, annotation in self.fields:
+            accessors.append(self._make_field_getter(field_name, annotation))
+            accessors.append(self._make_field_setter(field_name, annotation))
+        return accessors
+
+    def _make_field_getter(self, field_name, annotation):
+        return ast.FunctionDef(
+            name=_field_getter_name(field_name),
+            args=ast.arguments(
+                posonlyargs=[],
+                args=[ast.arg(arg="self", annotation=None)],
+                vararg=None,
+                kwonlyargs=[],
+                kw_defaults=[],
+                kwarg=None,
+                defaults=[],
+            ),
+            body=[
+                ast.Return(
+                    value=ast.Attribute(
+                        value=ast.Name(id="self", ctx=ast.Load()),
+                        attr=field_name,
+                        ctx=ast.Load(),
+                    )
+                )
+            ],
+            decorator_list=[],
+            returns=annotation,
+            type_comment=None,
+        )
+
+    def _make_field_setter(self, field_name, annotation):
+        return ast.FunctionDef(
+            name=_field_setter_name(field_name),
+            args=ast.arguments(
+                posonlyargs=[],
+                args=[
+                    ast.arg(arg="self", annotation=None),
+                    ast.arg(arg="value", annotation=annotation),
+                ],
+                vararg=None,
+                kwonlyargs=[],
+                kw_defaults=[],
+                kwarg=None,
+                defaults=[],
+            ),
+            body=[
+                ast.Assign(
+                    targets=[
+                        ast.Attribute(
+                            value=ast.Name(id="self", ctx=ast.Load()),
+                            attr=field_name,
+                            ctx=ast.Store(),
+                        )
+                    ],
+                    value=ast.Name(id="value", ctx=ast.Load()),
+                ),
+                ast.Return(value=ast.Name(id="value", ctx=ast.Load())),
+            ],
+            decorator_list=[],
+            returns=annotation,
+            type_comment=None,
+        )
+
+
+class JITClassProxy:
+    def __init__(self, meta: JITClassMeta, native_cls, handle, debug=0):
+        self.meta = meta
+        self.native_cls = native_cls
+        self.handle = handle
+        self.debug = debug
+        self.closed = False
+
+    def ensure_alive(self):
+        if self.closed:
+            raise JITError("jitclass object has been released")
+
+    def close(self):
+        if self.closed:
+            return
+
+        handle = self.handle
+        self.closed = True
+        self.handle = 0
+
+        _jit.jitclass_release(
+            self.meta.class_name,
+            handle,
+            int(self.debug > 0),
+        )
+
+
+def _close_jitclass_proxy(proxy, suppress=False):
+    try:
+        proxy.close()
+    except Exception:
+        if not suppress:
+            raise
+
+
+class JITNativeClass:
+    def __init__(self, *args, **kwargs):
+        proxy = type(self).__codon_constructor__(self, *args, **kwargs)
+        object.__setattr__(self, "__codon_jitclass_proxy__", proxy)
+        object.__setattr__(self, "__codon_handle__", proxy.handle)
+        object.__setattr__(
+            self,
+            "__codon_finalizer__",
+            weakref.finalize(self, _close_jitclass_proxy, proxy, True),
+        )
+
+    def close(self):
+        proxy = getattr(self, "__codon_jitclass_proxy__", None)
+        if proxy is not None:
+            proxy.close()
+            object.__setattr__(self, "__codon_handle__", proxy.handle)
+
+        finalizer = getattr(self, "__codon_finalizer__", None)
+        if finalizer is not None:
+            finalizer.detach()
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.close()
+
+    def __setattr__(self, name, value):
+        if name.startswith("__codon_"):
+            object.__setattr__(self, name, value)
+            return
+
+        field = getattr(type(self), name, None)
+        if isinstance(field, JITField):
+            field.__set__(self, value)
+            return
+
+        raise AttributeError(
+            "jitclass '{}' has no field '{}'".format(type(self).__name__, name)
+        )
+
+
+class JITClassCtor(JITCallable):
+    def __init__(self, meta: JITClassMeta, init: Any, debug=0, sample_size=5):
+        super().__init__(init, init.__name__, init.__module__, debug, sample_size)
+        self.meta = meta
+
+    def __call__(self, obj, *args, **kwargs):
+        def run():
+            bound_args = self.bind_args((obj,) + args, kwargs, drop_self=True)
+            arg_types = self.codon_types(bound_args)
+
+            if self.debug == 2:
+                print(
+                    f"[python] {self.meta.class_name}.{self.py_func.__name__}({bound_args})",
+                    file=sys.stderr,
+                )
+            handle = _jit.jitclass_new(
+                self.meta.class_name,
+                self.meta.native_class_name,
+                list(arg_types),
+                bound_args,
+                int(self.debug > 0),
+            )
+            return JITClassProxy(self.meta, type(obj), handle, self.debug)
+
+        return self.reset_on_jit_error(run)
+
+
+class JITMethod(JITCallable):
+    def __init__(self, meta: JITClassMeta, method: Any, debug=0, sample_size=5):
+        super().__init__(method, method.__name__, method.__module__, debug, sample_size)
+        self.meta = meta
+
+    def __get__(self, obj, owner):
+        if obj is None:
+            return self
+
+        @functools.wraps(self.py_func)
+        def bound(*args, **kwargs):
+            return self(obj, *args, **kwargs)
+
+        return bound
+
+    def __call__(self, obj, *args, **kwargs):
+        def run():
+            proxy = obj.__codon_jitclass_proxy__
+            proxy.ensure_alive()
+            bound_args = self.bind_args((obj,) + args, kwargs, drop_self=True)
+            arg_types = self.codon_types(bound_args)
+
+            if self.debug == 2:
+                print(
+                    f"[python] {self.meta.class_name}.{self.py_func.__name__}({bound_args})",
+                    file=sys.stderr,
+                )
+            return _jit.jitclass_call(
+                self.meta.class_name,
+                proxy.handle,
+                self.py_func.__name__,
+                list(arg_types),
+                bound_args,
+                int(self.debug > 0),
+            )
+
+        return self.reset_on_jit_error(run)
+
+
+class JITField(JITCallable):
+    def __init__(self, meta: JITClassMeta, field_name: str, debug=0, sample_size=5):
+        super().__init__(None, field_name, meta.py_cls.__module__, debug, sample_size)
+        self.meta = meta
+        self.field_name = field_name
+
+    def __get__(self, obj, owner):
+        if obj is None:
+            return self
+
+        def run():
+            proxy = obj.__codon_jitclass_proxy__
+            proxy.ensure_alive()
+            if self.debug == 2:
+                print(
+                    f"[python] {self.meta.class_name}.{self.field_name}",
+                    file=sys.stderr,
+                )
+            return _jit.jitclass_call(
+                self.meta.class_name,
+                proxy.handle,
+                _field_getter_name(self.field_name),
+                [],
+                (),
+                int(self.debug > 0),
+            )
+
+        return self.reset_on_jit_error(run)
+
+    def __set__(self, obj, value):
+        def run():
+            proxy = obj.__codon_jitclass_proxy__
+            proxy.ensure_alive()
+            bound_args = (value,)
+            arg_types = self.codon_types(bound_args)
+            if self.debug == 2:
+                print(
+                    f"[python] {self.meta.class_name}.{self.field_name} = {value!r}",
+                    file=sys.stderr,
+                )
+            _jit.jitclass_call(
+                self.meta.class_name,
+                proxy.handle,
+                _field_setter_name(self.field_name),
+                list(arg_types),
+                bound_args,
+                int(self.debug > 0),
+            )
+
+        return self.reset_on_jit_error(run)
+
+
+class JITClassCreator:
+    def __init__(self, py_cls, debug=0, sample_size=5):
+        if not inspect.isclass(py_cls):
+            raise TypeError("jitclass expects a class, got " + type(py_cls).__name__)
+
+        self.meta = JITClassMeta(py_cls, _make_native_class_name(py_cls))
+        self.debug = (
+            debug_override if debug_override else (0 if debug is None else debug)
+        )
+        self.sample_size = sample_size
+        self.compile()
+
+    def create(self):
+        meta = self.meta
+        namespace = {
+            "__module__": meta.py_cls.__module__,
+            "__qualname__": meta.py_cls.__qualname__,
+            "__doc__": meta.py_cls.__doc__,
+            "__codon_jitclass_meta__": meta,
+            "__codon_jitclass_name__": meta.class_name,
+            "__codon_constructor__": JITClassCtor(
+                meta, meta.init, self.debug, self.sample_size
+            ),
+        }
+
+        for method_name, method in meta.methods.items():
+            namespace[method_name] = JITMethod(
+                meta, method, self.debug, self.sample_size
+            )
+
+        for field_name in meta.fields:
+            namespace[field_name] = JITField(
+                meta, field_name, self.debug, self.sample_size
+            )
+
+        return type(meta.py_cls.__name__, (JITNativeClass,), namespace)
+
+    def compile(self):
+        class_code = self._parse()
+
+        if self.debug == 2:
+            print(f"[jit_debug] execute:\n{class_code}", file=sys.stderr)
+        try:
+            _jit.execute(
+                class_code, self.meta.source_file, 1, int(self.debug > 0)
+            )
+        except JITError:
+            _reset_jit()
+            raise
+
+    def _parse(self):
+        meta = self.meta
+        src = textwrap.dedent(inspect.getsource(meta.py_cls))
+        mod = ast.parse(src)
+        transformer = JITClassASTTransformer(meta)
+        mod = transformer.visit(mod)
+
+        meta.has_fields = transformer.has_fields
+        meta.bind_init(allow_default=not transformer.has_init and not meta.has_fields)
+        meta.bind_methods(transformer.method_names)
+        meta.bind_fields(transformer.fields)
+
+        if transformer.has_init and not meta.has_fields:
+            raise JITError("jitclass requires explicit field annotations")
+
+        mod = ast.fix_missing_locations(mod)
+        return astunparse.unparse(mod).replace("_@par", "@par")
+
+
+def jitclass(cls=None, debug=0):
+    def _decorate(t):
+        try:
+            return JITClassCreator(t, debug).create()
+        except JITError:
+            _reset_jit()
+            raise
+
+    return _decorate(cls) if cls else _decorate
+
+
+def _validate_method_args(args, method_name):
+    if args.vararg or args.kwarg:
+        raise JITError("jitclass does not support *args or **kwargs")
+    if args.kwonlyargs:
+        raise JITError("jitclass does not support keyword-only arguments")
+    if not args.args or args.args[0].arg != "self":
+        raise JITError("jitclass method '{}' must take self".format(method_name))
+
+
+def _field_getter_name(field_name):
+    return "_codon_jitclass_get_{}".format(field_name)
+
+
+def _field_setter_name(field_name):
+    return "_codon_jitclass_set_{}".format(field_name)
+
+
+def _make_native_class_name(py_cls):
+    qualname = getattr(py_cls, "__qualname__", py_cls.__name__)
+    name = re.sub(r"\W", "_", qualname.replace(".", "_"))
+    return f"__codon_jitclass_{name}"

--- a/test/python/cython_jit.py
+++ b/test/python/cython_jit.py
@@ -1,4 +1,5 @@
 from typing import Dict, List, Tuple
+import gc
 import numpy as np
 import codon
 
@@ -105,12 +106,82 @@ def test_error_handling():
     else:
         assert False
 
+def test_jitclass():
+    @codon.jitclass
+    class Point:
+        x: int
+        y: int
+
+        def __init__(self, x: int, y: int):
+            self.x = x
+            self.y = y
+
+        def total(self) -> int:
+            return self.x + self.y
+
+    p = Point(2, 3)
+    assert p.total() == 5
+    assert p.x == 2
+    assert p.y == 3
+
+    p.x = 10
+    p.y = 20
+    assert p.x == 10
+    assert p.y == 20
+    assert p.total() == 30
+
+    @codon.jit
+    def allocate_pressure(n: int) -> int:
+        acc = 0
+        for i in range(n):
+            values = [i, i + 1, i + 2, i + 3]
+            acc += values[0]
+        return acc
+
+    rooted = Point(7, 11)
+    assert allocate_pressure(4096) == sum(range(4096))
+    gc.collect()
+    assert rooted.total() == 18
+    rooted.close()
+
+    items = [Point(i, i + 1) for i in range(32)]
+    gc.collect()
+    assert sum(item.total() for item in items) == sum(2 * i + 1 for i in range(32))
+
+    with Point(4, 5) as q:
+        assert q.total() == 9
+    assert q.__codon_handle__ == 0
+    try:
+        q.total()
+    except codon.JITError:
+        pass
+    else:
+        assert False
+
+    p.close()
+    assert p.__codon_handle__ == 0
+    p.close()
+    try:
+        p.x
+    except codon.JITError:
+        pass
+    else:
+        assert False
+
+    @codon.jitclass
+    class Empty:
+        pass
+
+    e = Empty()
+    e.close()
+
 test_convertible()
 test_many()
 test_roundtrip()
 test_return_type()
 test_param_types()
 test_error_handling()
+test_jitclass()
 
 
 @codon.jit

--- a/test/python/cython_jit.py
+++ b/test/python/cython_jit.py
@@ -1,7 +1,9 @@
 from typing import Dict, List, Tuple
 import gc
+import weakref
 import numpy as np
 import codon
+from codon.decorator import _reset_jit
 
 @codon.convert
 class Foo:
@@ -120,9 +122,12 @@ def test_jitclass():
             return self.x + self.y
 
     p = Point(2, 3)
+    assert p.__codon_jitclass_proxy__ is not None
+    assert not p.__codon_jitclass_proxy__.closed
     assert p.total() == 5
     assert p.x == 2
     assert p.y == 3
+    stale = Point(1, 2)
 
     p.x = 10
     p.y = 20
@@ -148,9 +153,17 @@ def test_jitclass():
     gc.collect()
     assert sum(item.total() for item in items) == sum(2 * i + 1 for i in range(32))
 
+    temp = Point(13, 14)
+    temp_proxy = temp.__codon_jitclass_proxy__
+    temp_ref = weakref.ref(temp)
+    del temp
+    gc.collect()
+    assert temp_ref() is None
+    assert temp_proxy.closed
+
     with Point(4, 5) as q:
         assert q.total() == 9
-    assert q.__codon_handle__ == 0
+    assert q.__codon_jitclass_proxy__.closed
     try:
         q.total()
     except codon.JITError:
@@ -159,12 +172,20 @@ def test_jitclass():
         assert False
 
     p.close()
-    assert p.__codon_handle__ == 0
+    assert p.__codon_jitclass_proxy__.closed
     p.close()
     try:
         p.x
     except codon.JITError:
         pass
+    else:
+        assert False
+
+    _reset_jit()
+    try:
+        stale.total()
+    except codon.JITError as e:
+        assert "stale JIT context" in str(e)
     else:
         assert False
 


### PR DESCRIPTION
## Proposal: Native-backed Python Classes for Codon JIT via `codon.jitclass`

### Background

Codon already provides `codon.convert` as a way to expose Python classes to Codon JIT-compiled functions. This mechanism is useful for simple interoperability scenarios: a Python object can be converted into a Codon-compatible representation, passed into compiled code, and used from JIT functions.

However, `codon.convert` has several inherent limitations when the goal is to model Python classes as native Codon objects:

1. **Object identity and lifetime are not naturally preserved**

   `codon.convert` primarily treats Python objects as values that can be converted into Codon-side data structures. This works well for immutable or value-like objects, but it is not ideal for class instances that are expected to behave like long-lived mutable objects.

2. **Mutation semantics are limited**

   For Python classes with fields, users often expect operations such as:

   ```python
   obj.x = 10
   obj.update()
   print(obj.x)
   ```

   to operate on the same underlying object. With conversion-based interop, field updates may not naturally map to persistent native state unless the object is explicitly reconstructed or round-tripped.

3. **Methods are not represented as native class methods**

   `codon.convert` allows converted objects to be consumed by JIT functions, but it does not make the Python class itself a native Codon class with compiled methods, constructors, and field accessors. This limits the ability to express object-oriented workloads directly in the JIT layer.

4. **Performance opportunities are left on the table**

   A conversion-based approach introduces boundaries between Python objects and Codon values. For class-heavy workloads, repeatedly converting objects or routing behavior through Python-level wrappers can reduce the performance benefits expected from JIT compilation.

5. **The user model is less direct**

   Users who write normal Python classes usually expect a decorator-based workflow where the class itself becomes compiled, rather than manually converting instances or writing separate JIT functions around them.

Because of these limitations, we propose adding first-class support for JIT-compiled classes through `codon.jitclass`.

---

### Proposal

We propose adding `codon.jitclass`, a decorator that compiles a Python class into a native Codon class and exposes it through a Python proxy object.

Example:

```python
import codon

@codon.jitclass
class Point:
    x: int
    y: int

    def __init__(self, x: int, y: int):
        self.x = x
        self.y = y

    def norm2(self) -> int:
        return self.x * self.x + self.y * self.y

p = Point(3, 4)
print(p.norm2())  # 25

p.x = 6
print(p.norm2())  # 52
```

The class definition is compiled by Codon JIT. Python receives a lightweight object whose data and methods are backed by a native Codon instance.

---

### Key Capabilities

`codon.jitclass` supports:

- annotated fields,
- constructors,
- instance methods,
- field getters and setters,
- empty or method-only classes,
- explicit lifecycle management through `close()` and context managers.

Internally, each instance is stored in the JIT runtime using a handle. Method calls and field access are dispatched to compiled Codon wrappers.

The implementation also keeps native objects safe by rooting them in Codon’s GC while they are reachable from Python.

---

### Benefits

This feature extends Codon JIT from function-level acceleration to class-level acceleration.

Compared with `codon.convert`, `codon.jitclass` provides:

- persistent native-backed objects,
- natural Python syntax for methods and fields,
- mutable state preserved across calls,
- lower conversion overhead,
- safer lifetime management for native objects,
- better support for object-oriented Python workloads.

---

### Summary

`codon.convert` remains useful for converting Python values into Codon-compatible objects.

`codon.jitclass` addresses a different use case: compiling Python classes themselves into native Codon classes, while preserving a Python-friendly interface.

This makes Codon JIT more expressive and better suited for stateful, object-oriented code.