### PR TITLE
add runtime dependency in python dsl codon jit setup

### DIFF
--- a/jit/setup.py
+++ b/jit/setup.py
@@ -77,7 +77,7 @@ jit_extension = Extension(
 setup(
     name="codon-jit",
     version=__version__,
-    install_requires=["cython", "astunparse"],
+    install_requires=["cython", "astunparse", "numpy"],
     python_requires=">=3.6",
     description="Codon JIT decorator",
     url="https://exaloop.io",


### PR DESCRIPTION
fixes #808

### After adding the dependency
```bash
$ python3 -m pip install --no-cache-dir -e /home/swchoi/src/codon/install/python
Obtaining file:///home/swchoi/src/codon/install/python
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
  Preparing editable metadata (pyproject.toml) ... done
Requirement already satisfied: cython in /home/swchoi/.venvs/codon311/lib/python3.11/site-packages (from codon-jit==0.4.6) (3.2.4)
Requirement already satisfied: astunparse in /home/swchoi/.venvs/codon311/lib/python3.11/site-packages (from codon-jit==0.4.6) (1.6.3)
Collecting numpy (from codon-jit==0.4.6)
  Downloading numpy-2.4.4-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl.metadata (6.6 kB)
Requirement already satisfied: wheel<1.0,>=0.23.0 in /home/swchoi/.venvs/codon311/lib/python3.11/site-packages (from astunparse->codon-jit==0.4.6) (0.46.3)
Requirement already satisfied: six<2.0,>=1.6.1 in /home/swchoi/.venvs/codon311/lib/python3.11/site-packages (from astunparse->codon-jit==0.4.6) (1.17.0)
Requirement already satisfied: packaging>=24.0 in /home/swchoi/.venvs/codon311/lib/python3.11/site-packages (from wheel<1.0,>=0.23.0->astunparse->codon-jit==0.4.6) (26.0)
Downloading numpy-2.4.4-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl (16.9 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 16.9/16.9 MB 15.1 MB/s  0:00:01
Building wheels for collected packages: codon-jit
  Building editable for codon-jit (pyproject.toml) ... done
  Created wheel for codon-jit: filename=codon_jit-0.4.6-0.editable-cp311-cp311-linux_x86_64.whl size=2862 sha256=5e0759220cc59e043603a969f485d413814e888a9d3e9033674e7061fa6b5aec
  Stored in directory: /tmp/pip-ephem-wheel-cache-miyjcza7/wheels/ea/ed/42/c2da522f33b7feb448ba2b26e50a0a3e13717cc429a04d4626
Successfully built codon-jit
Installing collected packages: numpy, codon-jit
Successfully installed codon-jit-0.4.6 numpy-2.4.4

[notice] A new release of pip is available: 26.0.1 -> 26.1.1
[notice] To update, run: pip install --upgrade pip
(codon311) swchoi@swc-WIN:~/src/test_code/python_codon_dsl$ python3 -m pip list
Package    Version Editable project location
---------- ------- -------------------------------------
astunparse 1.6.3
codon-jit  0.4.6   /home/swchoi/src/codon/install/python
Cython     3.2.4
numpy      2.4.4
packaging  26.0
pip        26.0.1
setuptools 82.0.1
six        1.17.0
wheel      0.46.3
```
Installing `codon-jit` with pip now also installs the CPython NumPy package.

The output above was produced from my local Codon checkout, installed in editable mode from:

```bash
/home/swchoi/src/codon/install/python
```


### MRE 

This MRE is slightly different from the one in #808.  
It checks both the regular CPython NumPy path and the Codon JIT NumPy path in the same script.

```
from __future__ import annotations

import time

import numpy as py_np

try:
    import codon
except ModuleNotFoundError:
    codon = None


def python_numpy_sum(n: int) -> float:
    """Pure CPython + NumPy path."""
    arr = py_np.arange(n, dtype=py_np.float64)
    return ((arr * 2.0) + 1.0).sum()


if codon is not None:

    @codon.jit(debug=True)
    def codon_numpy_sum(n: int) -> float:
        """Codon JIT path.

        This `numpy` import is part of the Codon-compiled function body,
        so it refers to Codon-NumPy rather than CPython's NumPy module.
        """

        import numpy as np

        arr = np.arange(n, dtype=np.float64)
        return ((arr * 2.0) + 1.0).sum()

else:

    def codon_numpy_sum(n: int) -> float:
        raise RuntimeError(
            "codon-jit is not installed in this environment. "
            "Install it with `pip install codon-jit`, and make sure the "
            "Codon CLI/runtime is also installed."
        )


def main() -> None:
    n = 1_000_000

    print("Python NumPy module:", py_np.__file__)
    print("Codon import available:", codon is not None)
    print()

    t0 = time.time()
    py_ans = python_numpy_sum(n)
    t1 = time.time()
    print(f"[python numpy] result={py_ans:.1f} time={t1 - t0:.6f}s")

    if codon is None:
        print("[codon jit] skipped: codon-jit is not installed")
        return

    t0 = time.time()
    codon_ans = codon_numpy_sum(n)
    t1 = time.time()
    print(f"[codon numpy]  result={codon_ans:.1f} time={t1 - t0:.6f}s")


if __name__ == "__main__":
    main()

```

### Result

```
$ python3 numpy_call_paths_demo.py 
[codon::jit::execute] code:
def codon_numpy_sum(n: int) -> float:
    """Codon JIT path.

    This `numpy` import is part of the Codon-compiled function body,
    so it refers to Codon-NumPy rather than CPython's NumPy module.
    """

    import numpy as np

    arr = np.arange(n, dtype=np.float64)
    return ((arr * 2.0) + 1.0).sum()
-----
Python NumPy module: /home/swchoi/.venvs/codon311/lib/python3.11/site-packages/numpy/__init__.py
Codon import available: True

[python numpy] result=1000000000000.0 time=0.011559s
[python] codon_numpy_sum(['int'])
[codon::jit::executePython] wrapper:
@export
def __codon_wrapped__codon_numpy_sum_0(args: cobj) -> cobj:
    a0 = int.__from_py__(PyTuple_GetItem(args, 0))
    return codon_numpy_sum(a0).__to_py__()
-----
[codon numpy]  result=1000000000000.0 time=1.295281s
```

The script now runs successfully after installing `codon-jit`, because `python NumPy` is installed as a dependency.

This confirms that the JIT package can import the CPython NumPy module when it initializes the Python-side decorator logic, 

while the NumPy import inside the JIT-compiled function body is still handled as Codon-NumPy.
