### PR TITLE
JIT: add jitclass for native codon jit class(2/4)

### DIFF
--- a/codon/compiler/jit.cpp
+++ b/codon/compiler/jit.cpp
@@ -18,6 +18,8 @@ namespace {
 typedef int MainFunc(int, char **);
 typedef void InputFunc();
 typedef void *PyWrapperFunc(void *);
+typedef void *JITClassNewFunc(void *);
+typedef void *JITClassMethodFunc(void *, void *);
 
 const std::string JIT_FILENAME = "<jit>";
 } // namespace
@@ -29,15 +31,38 @@ JIT::JIT(const std::string &argv0, const std::string &mode,
                                           /*isTest=*/false,
                                           /*pyNumerics=*/false, /*pyExtension=*/false)),
       engine(std::make_unique<Engine>()), pydata(std::make_unique<PythonData>()),
-      mode(mode), forgetful(false) {
+      jitClassData(std::make_unique<JITClassData>()), mode(mode), forgetful(false) {
   if (!stdlibRoot.empty())
     compiler->getCache()->fs->add_search_path(stdlibRoot);
   compiler->getLLVMVisitor()->setJIT(true);
 }
 
+JIT::JITClassRoot::JITClassRoot(void *ptr) : slot(std::make_unique<void *>(ptr)) {
+  seq_gc_add_roots(slot.get(), slot.get() + 1);
+}
+
+JIT::JITClassRoot::~JITClassRoot() {
+  if (slot)
+    seq_gc_remove_roots(slot.get(), slot.get() + 1);
+}
+
+JIT::JITClassRoot &JIT::JITClassRoot::operator=(JITClassRoot &&other) noexcept {
+  if (this != &other) {
+    if (slot)
+      seq_gc_remove_roots(slot.get(), slot.get() + 1);
+    slot = std::move(other.slot);
+  }
+  return *this;
+}
+
+JIT::JITClassInstance::JITClassInstance(std::string className,
+                                        std::string nativeClassName, void *nativePtr)
+    : className(std::move(className)), nativeClassName(std::move(nativeClassName)),
+      nativePtr(nativePtr), root(nativePtr) {}
+
 void collectExecutableStmts(ast::Stmt *s, ast::SuiteStmt *final) {
-  if (cast<ast::FunctionStmt>(s) || cast<ast::ClassStmt>(s) ||
-      cast<ast::CommentStmt>(s))
+  if (ast::cast<ast::FunctionStmt>(s) || ast::cast<ast::ClassStmt>(s) ||
+      ast::cast<ast::CommentStmt>(s))
     return;
   if (auto ss = ast::cast<ast::SuiteStmt>(s)) {
     for (auto &si : *ss)
@@ -304,11 +329,77 @@ std::string buildPythonWrapper(const std::string &name, const std::string &wrapn
 
   return wrap.str();
 }
+std::string buildJITClassKey(const std::string &kind,
+                             const std::string &nativeClassName,
+                             const std::vector<std::string> &types,
+                             const std::string &methodName = "") {
+  std::stringstream key;
+  key << kind << "|" << nativeClassName;
+  if (!methodName.empty())
+    key << "|" << methodName;
+  for (const auto &t : types)
+    key << "|" << t;
+  return key.str();
+}
+
+std::string buildJITClassNewWrapper(const std::string &nativeClassName,
+                                    const std::string &wrapname,
+                                    const std::vector<std::string> &types) {
+  std::stringstream wrap;
+  wrap << "from internal.python import PyTuple_GetItem\n";
+  wrap << "@export\n";
+  wrap << "def " << wrapname << "(args: cobj) -> cobj:\n";
+  for (unsigned i = 0; i < types.size(); i++) {
+    wrap << "    a" << i << " = " << types[i] << ".__from_py__(PyTuple_GetItem(args, "
+         << i << "))\n";
+  }
+  wrap << "    obj = " << nativeClassName << "(";
+  for (unsigned i = 0; i < types.size(); i++) {
+    if (i > 0)
+      wrap << ", ";
+    wrap << "a" << i;
+  }
+  wrap << ")\n";
+  wrap << "    return obj.__raw__()\n";
+  return wrap.str();
+}
+
+std::string buildJITClassMethodWrapper(const std::string &nativeClassName,
+                                       const std::string &methodName,
+                                       const std::string &wrapname,
+                                       const std::vector<std::string> &types) {
+  std::stringstream wrap;
+  wrap << "from internal.python import PyTuple_GetItem\n";
+  wrap << "@export\n";
+  wrap << "def " << wrapname << "(self_obj: cobj, args: cobj) -> cobj:\n";
+  wrap << "    self = type._force_cast(self_obj, " << nativeClassName << ")\n";
+  for (unsigned i = 0; i < types.size(); i++) {
+    wrap << "    a" << i << " = " << types[i] << ".__from_py__(PyTuple_GetItem(args, "
+         << i << "))\n";
+  }
+  wrap << "    return self." << methodName << "(";
+  for (unsigned i = 0; i < types.size(); i++) {
+    if (i > 0)
+      wrap << ", ";
+    wrap << "a" << i;
+  }
+  wrap << ").__to_py__()\n";
+  return wrap.str();
+}
 } // namespace
 
 JIT::PythonData::PythonData() : cobj(nullptr), cache() {}
 
 ir::types::Type *JIT::PythonData::getCObjType(ir::Module *M) {
+  if (cobj)
+    return cobj;
+  cobj = M->getPointerType(M->getByteType());
+  return cobj;
+}
+
+JIT::JITClassData::JITClassData() : cobj(nullptr), ctorWrappers(), methodWrappers() {}
+
+ir::types::Type *JIT::JITClassData::getCObjType(ir::Module *M) {
   if (cobj)
     return cobj;
   cobj = M->getPointerType(M->getByteType());
@@ -374,6 +465,117 @@ JIT::JITResult JIT::executePython(const std::string &name,
   }
 }
 
+JIT::JITResult JIT::jitClassNew(const std::string &className,
+                                const std::string &nativeClassName,
+                                const std::vector<std::string> &types, void *args,
+                                bool debug) {
+  auto key = buildJITClassKey("new", nativeClassName, types);
+  auto &cache = jitClassData->ctorWrappers;
+  auto it = cache.find(key);
+  JITClassNewFunc *wrap;
+
+  if (it != cache.end()) {
+    const std::string name = ir::LLVMVisitor::getNameForFunction(it->second);
+    auto func = llvm::cantFail(engine->lookup(name));
+    wrap = func.toPtr<JITClassNewFunc>();
+  } else {
+    auto idx = cache.size();
+    auto wrapname = "__codon_jitclass_new_" + std::to_string(idx);
+    auto wrapper = buildJITClassNewWrapper(nativeClassName, wrapname, types);
+    if (debug)
+      fmt::print(stderr, "[codon::jit::jitClassNew] wrapper:\n{}-----\n", wrapper);
+    if (auto err = compile(wrapper).takeError()) {
+      auto errorInfo = llvm::toString(std::move(err));
+      return JITResult::error(errorInfo);
+    }
+
+    auto *M = compiler->getModule();
+    auto *func = M->getOrRealizeFunc(wrapname, {jitClassData->getCObjType(M)});
+    seqassertn(func, "could not access jitclass constructor wrapper '{}'", wrapname);
+    cache.emplace(key, func);
+
+    auto result = address(func);
+    if (auto err = result.takeError()) {
+      auto errorInfo = llvm::toString(std::move(err));
+      return JITResult::error(errorInfo);
+    }
+    wrap = (JITClassNewFunc *)result.get();
+  }
+
+  try {
+    auto *nativePtr = (*wrap)(args);
+    auto *instance = new JITClassInstance(className, nativeClassName, nativePtr);
+    return JITResult::success(instance);
+  } catch (const runtime::JITError &e) {
+    auto err = handleJITError(e);
+    auto errorInfo = llvm::toString(std::move(err));
+    return JITResult::error(errorInfo);
+  }
+}
+
+JIT::JITResult JIT::jitClassCall(const std::string &className,
+                                 JITClassInstance *instance,
+                                 const std::string &methodName,
+                                 const std::vector<std::string> &types, void *args,
+                                 bool debug) {
+  if (!instance)
+    return JITResult::error("jitclass object has been released");
+  if (instance->className != className)
+    return JITResult::error(
+        fmt::format("jitclass instance has type '{}', expected '{}'",
+                    instance->className, className));
+
+  auto key = buildJITClassKey("method", instance->nativeClassName, types, methodName);
+  auto &cache = jitClassData->methodWrappers;
+  auto it = cache.find(key);
+  JITClassMethodFunc *wrap;
+
+  if (it != cache.end()) {
+    const std::string name = ir::LLVMVisitor::getNameForFunction(it->second);
+    auto func = llvm::cantFail(engine->lookup(name));
+    wrap = func.toPtr<JITClassMethodFunc>();
+  } else {
+    auto idx = cache.size();
+    auto wrapname = "__codon_jitclass_method_" + std::to_string(idx);
+    auto wrapper = buildJITClassMethodWrapper(instance->nativeClassName, methodName,
+                                              wrapname, types);
+    if (debug)
+      fmt::print(stderr, "[codon::jit::jitClassCall] wrapper:\n{}-----\n", wrapper);
+    if (auto err = compile(wrapper).takeError()) {
+      auto errorInfo = llvm::toString(std::move(err));
+      return JITResult::error(errorInfo);
+    }
+
+    auto *M = compiler->getModule();
+    auto *cobj = jitClassData->getCObjType(M);
+    auto *func = M->getOrRealizeFunc(wrapname, {cobj, cobj});
+    seqassertn(func, "could not access jitclass method wrapper '{}'", wrapname);
+    cache.emplace(key, func);
+
+    auto result = address(func);
+    if (auto err = result.takeError()) {
+      auto errorInfo = llvm::toString(std::move(err));
+      return JITResult::error(errorInfo);
+    }
+    wrap = (JITClassMethodFunc *)result.get();
+  }
+
+  try {
+    auto *ans = (*wrap)(instance->nativePtr, args);
+    return JITResult::success(ans);
+  } catch (const runtime::JITError &e) {
+    auto err = handleJITError(e);
+    auto errorInfo = llvm::toString(std::move(err));
+    return JITResult::error(errorInfo);
+  }
+}
+
+JIT::JITResult JIT::jitClassRelease(JITClassInstance *instance) {
+  // Deleting the control block also removes the RAII GC root.
+  delete instance;
+  return JITResult::success();
+}
+
 } // namespace jit
 } // namespace codon
 
@@ -409,6 +611,47 @@ CJITResult jit_execute_safe(void *jit, char *code, char *file, int32_t line,
                             uint8_t debug) {
   auto t = ((codon::jit::JIT *)jit)
                ->executeSafe(std::string(code), std::string(file), line, bool(debug));
+  void *result = t.result;
+  char *message =
+      t.message.empty() ? nullptr : strndup(t.message.c_str(), t.message.size());
+  return {result, message};
+}
+
+CJITResult jitclass_new(void *jit, char *class_name, char *native_class_name,
+                        char **types, size_t types_size, void *args, uint8_t debug) {
+  std::vector<std::string> cppTypes;
+  cppTypes.reserve(types_size);
+  for (size_t i = 0; i < types_size; i++)
+    cppTypes.emplace_back(types[i]);
+  auto t = ((codon::jit::JIT *)jit)
+               ->jitClassNew(std::string(class_name), std::string(native_class_name),
+                             cppTypes, args, bool(debug));
+  void *result = t.result;
+  char *message =
+      t.message.empty() ? nullptr : strndup(t.message.c_str(), t.message.size());
+  return {result, message};
+}
+
+CJITResult jitclass_call(void *jit, char *class_name, void *instance, char *method_name,
+                         char **types, size_t types_size, void *args, uint8_t debug) {
+  std::vector<std::string> cppTypes;
+  cppTypes.reserve(types_size);
+  for (size_t i = 0; i < types_size; i++)
+    cppTypes.emplace_back(types[i]);
+  auto t =
+      ((codon::jit::JIT *)jit)
+          ->jitClassCall(std::string(class_name),
+                         static_cast<codon::jit::JIT::JITClassInstance *>(instance),
+                         std::string(method_name), cppTypes, args, bool(debug));
+  void *result = t.result;
+  char *message =
+      t.message.empty() ? nullptr : strndup(t.message.c_str(), t.message.size());
+  return {result, message};
+}
+
+CJITResult jitclass_release(void *instance) {
+  auto t = codon::jit::JIT::jitClassRelease(
+      static_cast<codon::jit::JIT::JITClassInstance *>(instance));
   void *result = t.result;
   char *message =
       t.message.empty() ? nullptr : strndup(t.message.c_str(), t.message.size());

--- a/codon/compiler/jit.h
+++ b/codon/compiler/jit.h
@@ -51,6 +51,45 @@ public:
     ir::types::Type *getCObjType(ir::Module *M);
   };
 
+  struct JITClassData {
+    ir::types::Type *cobj;
+    std::unordered_map<std::string, ir::Func *> ctorWrappers;
+    std::unordered_map<std::string, ir::Func *> methodWrappers;
+
+    JITClassData();
+    ir::types::Type *getCObjType(ir::Module *M);
+  };
+
+  // RAII root for Codon GC-managed objects exposed through Python-owned instances.
+  struct JITClassRoot {
+    std::unique_ptr<void *> slot;
+
+    explicit JITClassRoot(void *ptr);
+    ~JITClassRoot();
+
+    JITClassRoot(JITClassRoot &&) noexcept = default;
+    JITClassRoot &operator=(JITClassRoot &&) noexcept;
+    JITClassRoot(const JITClassRoot &) = delete;
+    JITClassRoot &operator=(const JITClassRoot &) = delete;
+  };
+
+  struct JITClassInstance {
+    std::string className;
+    std::string nativeClassName;
+    void *nativePtr;
+
+    // Keeps the underlying Codon object alive while Python can still reach it.
+    JITClassRoot root;
+
+    JITClassInstance(std::string className, std::string nativeClassName,
+                     void *nativePtr);
+
+    JITClassInstance(JITClassInstance &&) noexcept = default;
+    JITClassInstance &operator=(JITClassInstance &&) noexcept = default;
+    JITClassInstance(const JITClassInstance &) = delete;
+    JITClassInstance &operator=(const JITClassInstance &) = delete;
+  };
+
   struct JITResult {
     void *result;
     std::string message;
@@ -64,6 +103,7 @@ private:
   std::unique_ptr<Compiler> compiler;
   std::unique_ptr<Engine> engine;
   std::unique_ptr<PythonData> pydata;
+  std::unique_ptr<JITClassData> jitClassData;
   std::string mode;
   bool forgetful = false;
 
@@ -99,6 +139,15 @@ public:
                           bool debug);
   JITResult executeSafe(const std::string &code, const std::string &file, int line,
                         bool debug);
+
+  // JITClass
+  JITResult jitClassNew(const std::string &className,
+                        const std::string &nativeClassName,
+                        const std::vector<std::string> &types, void *args, bool debug);
+  JITResult jitClassCall(const std::string &className, JITClassInstance *instance,
+                         const std::string &methodName,
+                         const std::vector<std::string> &types, void *args, bool debug);
+  static JITResult jitClassRelease(JITClassInstance *instance);
 
   // Errors
   llvm::Error handleJITError(const runtime::JITError &e);

--- a/codon/compiler/jit_extern.h
+++ b/codon/compiler/jit_extern.h
@@ -24,6 +24,16 @@ struct CJITResult jit_execute_python(void *jit, char *name, char **types,
 struct CJITResult jit_execute_safe(void *jit, char *code, char *file, int32_t line,
                                    uint8_t debug);
 
+struct CJITResult jitclass_new(void *jit, char *class_name, char *native_class_name,
+                               char **types, size_t types_size, void *args,
+                               uint8_t debug);
+
+struct CJITResult jitclass_call(void *jit, char *class_name, void *instance,
+                                char *method_name, char **types, size_t types_size,
+                                void *args, uint8_t debug);
+
+struct CJITResult jitclass_release(void *instance);
+
 char *get_jit_library();
 
 #ifdef __cplusplus

--- a/jit/codon/__init__.py
+++ b/jit/codon/__init__.py
@@ -1,9 +1,17 @@
 # Copyright (C) 2022-2026 Exaloop Inc. <https://exaloop.io>
 
 __all__ = [
-    "jit", "convert", "JITError", "JITWrapper", "_jit_register_fn", "_jit"
+    "jit",
+    "convert",
+    "jitclass",
+    "JITError",
+    "JITWrapper",
+    "_jit_register_fn",
+    "_jit",
 ]
 
 from .decorator import jit, convert, execute, JITError, JITWrapper, _jit_register_fn, _jit_callback_fn, _jit
+
+from .jitclass import jitclass
 
 __codon__ = False

--- a/jit/codon/decorator.py
+++ b/jit/codon/decorator.py
@@ -146,6 +146,59 @@ def _codon_type(arg, **kwargs):
 def _codon_types(args, **kwargs):
     return tuple(_codon_type(arg, **kwargs) for arg in args)
 
+def bind_args(func, args, kwargs, drop_self=False):
+    bound_self = None
+    if inspect.ismethod(func) and func.__self__ is not None:
+        bound_self = func.__self__
+        func = func.__func__
+        args = (bound_self, *args)
+    sig = inspect.signature(func)
+    bound_args = sig.bind(*args, **kwargs)
+    bound_args.apply_defaults()
+    names = list(sig.parameters)
+    if drop_self and names and names[0] == "self":
+        names = names[1:]
+    return tuple(bound_args.arguments[p] for p in names)
+
+class JITCallable:
+    def __init__(self, py_func, obj_name, module, debug=0, sample_size=5, pyvars=None):
+        self.py_func = py_func
+        self.obj_name = obj_name
+        self.module = module
+        self.debug = debug
+        self.sample_size = sample_size
+        self.pyvars = pyvars or []
+    def codon_types(self, args):
+        return _codon_types(args, debug=self.debug, sample_size=self.sample_size)
+    def bind_args(self, args, kwargs, drop_self=False):
+        if self.py_func is not None:
+            return bind_args(self.py_func, args, kwargs, drop_self)
+        return (*args, *kwargs.values())
+    def reset_on_jit_error(self, fn):
+        try:
+            return fn()
+        except JITError:
+            _reset_jit()
+            raise
+    def __call__(self, *args, **kwargs):
+        def run():
+            bound_args = self.bind_args(args, kwargs)
+            types = self.codon_types(bound_args)
+            if self.debug > 0:
+                print(
+                    "[python] {}({})".format(self.obj_name, list(types)),
+                    file=sys.stderr,
+                )
+            return _jit.run_wrapper(
+                self.obj_name,
+                list(types),
+                self.module,
+                list(self.pyvars),
+                bound_args,
+                int(self.debug > 0),
+            )
+        return self.reset_on_jit_error(run)
+
 def _reset_jit():
     global _jit
     _jit = JITWrapper()
@@ -258,31 +311,16 @@ def _jit_callback_fn(fn,
                      pyvars=None,
                      *args,
                      **kwargs):
-    if fn is not None:
-        sig = inspect.signature(fn)
-        bound_args = sig.bind(*args, **kwargs)
-        bound_args.apply_defaults()
-        args = tuple(bound_args.arguments[param] for param in sig.parameters)
-    else:
-        args = (*args, *kwargs.values())
-
-    try:
-        types = _codon_types(args, debug=debug, sample_size=sample_size)
-        if debug > 0:
-            print("[python] {}({})".format(obj_name, list(types)), file=sys.stderr)
-        return _jit.run_wrapper(
-            obj_name, list(types), module, list(pyvars), args, int(debug > 0)
-        )
-    except JITError:
-        _reset_jit()
-        raise
+    return JITCallable(fn, obj_name, module, debug, sample_size, pyvars)(
+        *args, **kwargs
+    )
 
 def _jit_str_fn(fstr, debug=0, sample_size=5, pyvars=None):
     obj_name = _jit_register_fn(fstr, pyvars, debug)
+    jit_func = JITCallable(None, obj_name, "__main__", debug, sample_size, pyvars)
 
     def wrapped(*args, **kwargs):
-        return _jit_callback_fn(None, obj_name, "__main__", debug, sample_size,
-                                pyvars, *args, **kwargs)
+        return jit_func(*args, **kwargs)
 
     return wrapped
 
@@ -304,11 +342,11 @@ def jit(fn=None, debug=0, sample_size=5, pyvars=None):
 
     def _decorate(f):
         obj_name = _jit_register_fn(f, pyvars, debug)
+        jit_func = JITCallable(f, obj_name, f.__module__, debug, sample_size, pyvars)
 
         @functools.wraps(f)
         def wrapped(*args, **kwargs):
-            return _jit_callback_fn(f, obj_name, f.__module__, debug,
-                                    sample_size, pyvars, *args, **kwargs)
+            return jit_func(*args, **kwargs)
 
         return wrapped
 

--- a/jit/codon/jit.pxd
+++ b/jit/codon/jit.pxd
@@ -1,5 +1,6 @@
 # Copyright (C) 2022-2025 Exaloop Inc. <https://exaloop.io>
 
+from libc.stddef cimport size_t
 from libc.stdint cimport int32_t, uint8_t
 
 cdef extern from "codon/compiler/jit_extern.h":
@@ -19,4 +20,15 @@ cdef extern from "codon/compiler/jit_extern.h":
         void *jit, char *name, char **types, size_t types_size,
         char *pyModule, char **py_vars, size_t py_vars_size,
         void *arg, uint8_t debug
+    )
+    cdef CJITResult c_jitclass_new "jitclass_new"(
+        void *jit, char *class_name, char *native_class_name,
+        char **types, size_t types_size, void *args, uint8_t debug
+    )
+    cdef CJITResult c_jitclass_call "jitclass_call"(
+        void *jit, char *class_name, void *instance, char *method_name,
+        char **types, size_t types_size, void *args, uint8_t debug
+    )
+    cdef CJITResult c_jitclass_release "jitclass_release"(
+        void *instance
     )

--- a/jit/codon/jit.pyx
+++ b/jit/codon/jit.pyx
@@ -6,6 +6,7 @@
 # cython: c_string_encoding=utf8
 
 cimport codon.jit
+from libc.stddef cimport size_t
 from libc.stdlib cimport malloc, calloc, free
 from libc.string cimport strcpy
 from libc.stdint cimport int32_t, uint8_t
@@ -22,6 +23,95 @@ cdef str get_free_str(char *s):
         return py_s.decode('utf-8')
     finally:
         free(s)
+
+
+cdef class JITClassInstanceHandle:
+    """Owns the opaque native jitclass control block returned by C++."""
+    cdef void* instance
+
+    def __cinit__(self):
+        self.instance = NULL
+
+    cdef void set_instance(self, void* instance):
+        self.instance = instance
+
+    cdef void* get_instance(self):
+        return self.instance
+
+    cdef void* require_instance(self) except NULL:
+        if self.instance is NULL:
+            raise JITError("jitclass object has been released")
+        return self.instance
+
+    def close(self):
+        cdef codon.jit.CJITResult result
+        cdef void* instance
+        if self.instance is NULL:
+            return
+
+        # Invalidate first so re-entrant cleanup cannot release the same block twice.
+        instance = self.instance
+        self.instance = NULL
+        result = codon.jit.c_jitclass_release(instance)
+        if result.error is not NULL:
+            msg = get_free_str(result.error)
+            raise JITError(msg)
+
+    @property
+    def closed(self):
+        return self.instance is NULL
+
+    cdef object _call_with_jit(self, void* jit, str class_name, str method_name,
+                              list types, args, debug):
+        cdef codon.jit.CJITResult result
+        cdef size_t types_size = len(types)
+        cdef size_t alloc_size = types_size if types_size > 0 else 1
+        cdef char** c_types
+        cdef void* instance = self.require_instance()
+        cdef bytes encoded
+        cdef str msg
+        if jit is NULL:
+            raise JITError("JIT context has been released")
+
+        c_types = <char**>calloc(alloc_size, sizeof(char*))
+        if not c_types:
+            raise JITError("Cython allocation failed")
+        try:
+            for i, s in enumerate(types):
+                encoded = s.encode('utf-8')
+                c_types[i] = <char*>malloc(len(encoded) + 1)
+                if not c_types[i]:
+                    raise JITError("Cython allocation failed")
+                strcpy(c_types[i], encoded)
+            result = codon.jit.c_jitclass_call(
+                jit, class_name.encode('utf-8'), instance,
+                method_name.encode('utf-8'), c_types, types_size,
+                <void *>args, <uint8_t>debug
+            )
+            if result.error is NULL:
+                return <object>result.result
+            else:
+                msg = get_free_str(result.error)
+                raise JITError(msg)
+        finally:
+            for i in range(len(types)):
+                free(c_types[i])
+            free(c_types)
+
+    def call_with_jit(self, JITWrapper jit_wrapper, class_name: str, method_name: str,
+                      types: list[str], args, debug) -> object:
+        """Call a native method through the current JIT wrapper."""
+        if jit_wrapper is None:
+            raise JITError("JIT context has been released")
+        return self._call_with_jit(jit_wrapper.jit, class_name, method_name, types, args, debug)
+
+    def __dealloc__(self):
+        cdef void* instance
+        if self.instance is not NULL:
+            # Final safety net for paths that did not call close() explicitly.
+            instance = self.instance
+            self.instance = NULL
+            codon.jit.c_jitclass_release(instance)
 
 
 cdef class JITWrapper:
@@ -43,7 +133,8 @@ cdef class JITWrapper:
             msg = get_free_str(result.error)
             raise JITError(msg)
 
-    def run_wrapper(self, name: str, types: list[str], module: str, pyvars: list[str], args, debug) -> object:
+    def run_wrapper(self, name: str, types: list[str], module: str,
+                    pyvars: list[str], args, debug) -> object:
         cdef char** c_types = <char**>calloc(len(types), sizeof(char*))
         cdef char** c_pyvars = <char**>calloc(len(pyvars), sizeof(char*))
         if not c_types or not c_pyvars:
@@ -75,6 +166,37 @@ cdef class JITWrapper:
             for i in range(len(pyvars)):
                 free(c_pyvars[i])
             free(c_pyvars)
+
+    def jitclass_new(self, class_name: str, native_class_name: str,
+                     types: list[str], args, debug) -> JITClassInstanceHandle:
+        """Create a native jitclass instance and wrap it in a Python-owned handle."""
+        cdef size_t types_size = len(types)
+        cdef size_t alloc_size = types_size if types_size > 0 else 1
+        cdef char** c_types = <char**>calloc(alloc_size, sizeof(char*))
+        cdef JITClassInstanceHandle handle
+        if not c_types:
+            raise JITError("Cython allocation failed")
+        try:
+            for i, s in enumerate(types):
+                bytes = s.encode('utf-8')
+                c_types[i] = <char*>malloc(len(bytes) + 1)
+                strcpy(c_types[i], bytes)
+            result = codon.jit.c_jitclass_new(
+                self.jit, class_name.encode('utf-8'),
+                native_class_name.encode('utf-8'),
+                c_types, types_size, <void *>args, <uint8_t>debug
+            )
+            if result.error is NULL:
+                handle = JITClassInstanceHandle()
+                handle.set_instance(result.result)
+                return handle
+            else:
+                msg = get_free_str(result.error)
+                raise JITError(msg)
+        finally:
+            for i in range(len(types)):
+                free(c_types[i])
+            free(c_types)
 
 
 def codon_library():

--- a/jit/codon/jitclass.py
+++ b/jit/codon/jitclass.py
@@ -1,0 +1,325 @@
+# Copyright (C) 2022-2026 Exaloop Inc. <https://exaloop.io>
+from __future__ import annotations
+
+import ast
+import functools
+import inspect
+import re
+import sys
+import textwrap
+import weakref
+import astunparse
+
+from typing import Any
+
+from .decorator import (
+    JITCallable,
+    JITError,
+    _jit,
+    _reset_jit,
+    debug_override,
+)
+
+
+def _jitclass_default_init(self):
+    pass
+
+
+class JITClassMeta:
+    """Static metadata extracted from the original Python class."""
+
+    def __init__(self, py_cls, native_class_name):
+        self.py_cls = py_cls
+        self.class_name = py_cls.__name__
+        self.native_class_name = native_class_name
+        self.source_file = inspect.getsourcefile(py_cls) or "<internal>"
+        self.init = None
+        self.methods = {}
+        self.has_fields = False
+
+    def bind_init(self, allow_default=False):
+        init = self.py_cls.__dict__.get("__init__")
+        if init is None:
+            if not allow_default:
+                raise JITError("jitclass requires an __init__ method")
+            init = _jitclass_default_init
+        self.init = init
+
+    def bind_methods(self, method_names):
+        self.methods = {name: self.py_cls.__dict__[name] for name in method_names}
+
+
+class JITClassASTTransformer(ast.NodeTransformer):
+    """Validate a jitclass and rewrite it into the native Codon class body."""
+
+    def __init__(self, meta: JITClassMeta):
+        self.meta = meta
+        self.has_fields = False
+        self.has_init = False
+        self.method_names = []
+
+    def visit_Module(self, node):
+        class_nodes = [stmt for stmt in node.body if isinstance(stmt, ast.ClassDef)]
+        if not class_nodes:
+            raise JITError("jitclass expects a class definition")
+
+        node.body = [self.visit(class_nodes[0])]
+        return node
+
+    def visit_ClassDef(self, node):
+        if node.bases or node.keywords:
+            raise JITError("jitclass does not support inheritance")
+
+        node.decorator_list = []
+        node.name = self.meta.native_class_name
+        node.body = [self._visit_class_stmt(stmt) for stmt in node.body]
+        return node
+
+    def _visit_class_stmt(self, stmt):
+        if isinstance(stmt, ast.AnnAssign):
+            if not isinstance(stmt.target, ast.Name):
+                raise JITError("jitclass fields must be simple names")
+            if stmt.value is not None:
+                raise JITError("jitclass fields cannot have default values")
+            self.has_fields = True
+            return stmt
+
+        if isinstance(stmt, ast.FunctionDef):
+            if stmt.name.startswith("_codon_jitclass_"):
+                raise JITError(
+                    "method name '{}' is reserved for jitclass".format(stmt.name)
+                )
+            if stmt.decorator_list:
+                raise JITError("jitclass methods cannot have decorators")
+            _validate_method_args(stmt.args, stmt.name)
+            if stmt.name == "__init__":
+                self.has_init = True
+            else:
+                self.method_names.append(stmt.name)
+            return stmt
+
+        if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Constant):
+            return stmt
+
+        if isinstance(stmt, ast.Pass):
+            return stmt
+
+        raise JITError(
+            "unsupported statement in jitclass '{}'".format(self.meta.class_name)
+        )
+
+
+class JITClassProxy:
+    """Holds the native handle for one Python-visible jitclass instance."""
+
+    def __init__(self, meta: JITClassMeta, native_cls, handle, debug=0):
+        self.meta = meta
+        self.native_cls = native_cls
+        self.handle = handle
+        self.debug = debug
+
+    @property
+    def closed(self):
+        return self.handle is None or self.handle.closed
+
+    def close(self):
+        if self.handle is not None:
+            self.handle.close()
+
+
+def _close_jitclass_proxy(proxy, suppress=False):
+    """Close a proxy from weakref finalization without relying on __del__."""
+    try:
+        proxy.close()
+    except Exception:
+        if not suppress:
+            raise
+
+
+class JITNativeClass:
+    """Base class for Python objects backed by native jitclass instances."""
+
+    def __init__(self, *args, **kwargs):
+        proxy = type(self).__codon_constructor__(self, *args, **kwargs)
+        object.__setattr__(self, "__codon_jitclass_proxy__", proxy)
+        # weakref.finalize avoids __del__ cycles while ensuring native cleanup.
+        object.__setattr__(
+            self,
+            "__codon_finalizer__",
+            weakref.finalize(self, _close_jitclass_proxy, proxy, True),
+        )
+
+    def close(self):
+        proxy = getattr(self, "__codon_jitclass_proxy__", None)
+        if proxy is not None:
+            proxy.close()
+
+        finalizer = getattr(self, "__codon_finalizer__", None)
+        if finalizer is not None:
+            finalizer.detach()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.close()
+
+
+class JITClassCtor(JITCallable):
+    """Descriptor-like constructor that materializes the native instance."""
+
+    def __init__(self, meta: JITClassMeta, init: Any, debug=0, sample_size=5):
+        super().__init__(init, init.__name__, init.__module__, debug, sample_size)
+        self.meta = meta
+
+    def __call__(self, obj, *args, **kwargs):
+        def run():
+            bound_args = self.bind_args((obj,) + args, kwargs, drop_self=True)
+            arg_types = self.codon_types(bound_args)
+
+            if self.debug == 2:
+                print(
+                    f"[python] {self.meta.class_name}.{self.py_func.__name__}({bound_args})",
+                    file=sys.stderr,
+                )
+            handle = _jit.jitclass_new(
+                self.meta.class_name,
+                self.meta.native_class_name,
+                list(arg_types),
+                bound_args,
+                int(self.debug > 0),
+            )
+            return JITClassProxy(self.meta, type(obj), handle, self.debug)
+
+        return self.reset_on_jit_error(run)
+
+
+class JITMethod(JITCallable):
+    """Method descriptor that dispatches calls to the native jitclass object."""
+
+    def __init__(self, meta: JITClassMeta, method: Any, debug=0, sample_size=5):
+        super().__init__(method, method.__name__, method.__module__, debug, sample_size)
+        self.meta = meta
+
+    def __get__(self, obj, owner):
+        if obj is None:
+            return self
+
+        @functools.wraps(self.py_func)
+        def bound(*args, **kwargs):
+            return self(obj, *args, **kwargs)
+
+        return bound
+
+    def __call__(self, obj, *args, **kwargs):
+        def run():
+            proxy = obj.__codon_jitclass_proxy__
+            bound_args = self.bind_args((obj,) + args, kwargs, drop_self=True)
+            arg_types = self.codon_types(bound_args)
+
+            if self.debug == 2:
+                print(
+                    f"[python] {self.meta.class_name}.{self.py_func.__name__}({bound_args})",
+                    file=sys.stderr,
+                )
+            return proxy.handle.call_with_jit(
+                _jit,
+                self.meta.class_name,
+                self.py_func.__name__,
+                list(arg_types),
+                bound_args,
+                int(self.debug > 0),
+            )
+
+        return self.reset_on_jit_error(run)
+
+
+class JITClassCreator:
+    """Compiles the native class and builds the Python proxy type."""
+
+    def __init__(self, py_cls, debug=0, sample_size=5):
+        if not inspect.isclass(py_cls):
+            raise TypeError("jitclass expects a class, got " + type(py_cls).__name__)
+
+        self.meta = JITClassMeta(py_cls, _make_native_class_name(py_cls))
+        self.debug = (
+            debug_override if debug_override else (0 if debug is None else debug)
+        )
+        self.sample_size = sample_size
+        self.compile()
+
+    def create(self):
+        meta = self.meta
+        namespace = {
+            "__module__": meta.py_cls.__module__,
+            "__qualname__": meta.py_cls.__qualname__,
+            "__doc__": meta.py_cls.__doc__,
+            "__codon_jitclass_meta__": meta,
+            "__codon_jitclass_name__": meta.class_name,
+            "__codon_constructor__": JITClassCtor(
+                meta, meta.init, self.debug, self.sample_size
+            ),
+        }
+
+        for method_name, method in meta.methods.items():
+            namespace[method_name] = JITMethod(
+                meta, method, self.debug, self.sample_size
+            )
+
+        return type(meta.py_cls.__name__, (JITNativeClass,), namespace)
+
+    def compile(self):
+        class_code = self._parse()
+
+        if self.debug == 2:
+            print(f"[jit_debug] execute:\n{class_code}", file=sys.stderr)
+        try:
+            _jit.execute(
+                class_code, self.meta.source_file, 1, int(self.debug > 0)
+            )
+        except JITError:
+            _reset_jit()
+            raise
+
+    def _parse(self):
+        meta = self.meta
+        src = textwrap.dedent(inspect.getsource(meta.py_cls))
+        mod = ast.parse(src)
+        transformer = JITClassASTTransformer(meta)
+        mod = transformer.visit(mod)
+
+        meta.has_fields = transformer.has_fields
+        meta.bind_init(allow_default=not transformer.has_init and not meta.has_fields)
+        meta.bind_methods(transformer.method_names)
+
+        if transformer.has_init and not meta.has_fields:
+            raise JITError("jitclass requires explicit field annotations")
+
+        mod = ast.fix_missing_locations(mod)
+        return astunparse.unparse(mod).replace("_@par", "@par")
+
+
+def jitclass(cls=None, debug=0):
+    def _decorate(t):
+        try:
+            return JITClassCreator(t, debug).create()
+        except JITError:
+            _reset_jit()
+            raise
+
+    return _decorate(cls) if cls else _decorate
+
+
+def _validate_method_args(args, method_name):
+    if args.vararg or args.kwarg:
+        raise JITError("jitclass does not support *args or **kwargs")
+    if args.kwonlyargs:
+        raise JITError("jitclass does not support keyword-only arguments")
+    if not args.args or args.args[0].arg != "self":
+        raise JITError("jitclass method '{}' must take self".format(method_name))
+
+
+def _make_native_class_name(py_cls):
+    qualname = getattr(py_cls, "__qualname__", py_cls.__name__)
+    name = re.sub(r"\W", "_", qualname.replace(".", "_"))
+    return f"__codon_jitclass_{name}"

--- a/test/python/cython_jit.py
+++ b/test/python/cython_jit.py
@@ -1,4 +1,6 @@
 from typing import Dict, List, Tuple
+import gc
+import weakref
 import numpy as np
 import codon
 
@@ -105,12 +107,78 @@ def test_error_handling():
     else:
         assert False
 
+def test_jitclass():
+    @codon.jitclass
+    class Point:
+        x: int
+        y: int
+
+        def __init__(self, x: int, y: int):
+            self.x = x
+            self.y = y
+
+        def total(self) -> int:
+            return self.x + self.y
+
+    p = Point(2, 3)
+    assert p.__codon_jitclass_proxy__ is not None
+    assert not p.__codon_jitclass_proxy__.closed
+    assert p.total() == 5
+
+    @codon.jit
+    def allocate_pressure(n: int) -> int:
+        acc = 0
+        for i in range(n):
+            values = [i, i + 1, i + 2, i + 3]
+            acc += values[0]
+        return acc
+
+    rooted = Point(7, 11)
+    assert allocate_pressure(4096) == sum(range(4096))
+    gc.collect()
+    assert rooted.total() == 18
+    rooted.close()
+
+    items = [Point(i, i + 1) for i in range(32)]
+    gc.collect()
+    assert sum(item.total() for item in items) == sum(2 * i + 1 for i in range(32))
+
+    temp = Point(13, 14)
+    temp_proxy = temp.__codon_jitclass_proxy__
+    temp_ref = weakref.ref(temp)
+    del temp
+    gc.collect()
+    assert temp_ref() is None
+    assert temp_proxy.closed
+
+    with Point(4, 5) as q:
+        assert q.total() == 9
+    assert q.__codon_jitclass_proxy__.closed
+    try:
+        q.total()
+    except codon.JITError:
+        pass
+    else:
+        assert False
+
+    p.close()
+    assert p.__codon_jitclass_proxy__.closed
+    p.close()
+
+    @codon.jitclass
+    class Empty:
+        pass
+
+    e = Empty()
+    e.close()
+
 test_convertible()
 test_many()
 test_roundtrip()
 test_return_type()
 test_param_types()
 test_error_handling()
+test_jitclass()
 
 
 @codon.jit


### PR DESCRIPTION
**Description:** A new `codon.jitclass` decorator has been added, and this PR implements the core functionality outlined in [RFC: Native-backed Python Classes for Codon JIT via `codon.jitclass`](https://github.com/exaloop/codon/discussions/815#discussioncomment-17016134). Below is an introduction to the implementation approach of this PR based on core components mentioned in the RFC:

### 1. Class-level JIT compilation

`JITClassCreator` first parses and rewrites the Python class AST into a Codon-compatible native class definition. The `JITClassASTTransformer` validates the supported class shape, rejects unsupported constructs such as inheritance, method decorators, default field values, *args, **kwargs, and keyword-only arguments, etc.

The returned class is a subclass of `JITNativeClass`. Manually bind the constructor `JITClassCtor` and member method `JITMethod` to this class, and record the metadata of the original Python type at the same time.

### 2. Native object construction

Python construction is handled by a descriptor-backed constructor. The constructor binds Python arguments, drops self, infers Codon argument types, and calls the Cython JIT bridge. The C++ JIT layer then looks up or creates a constructor wrapper specialized for those argument types. 

The generated constructor wrapper converts each Python argument with `T.__from_py__`, constructs the native Codon object, and returns its raw native representation via `obj.__raw__()`. The returned pointer is stored in a native `JITClassInstance` control block and wrapped by a Python-owned Cython handle. 

### 3. Method dispatch

Methods are exposed as Python descriptors. A bound method call is routed through the instance proxy and native handle. For each distinct (native class, method name, argument types) combination, the JIT layer either reuses a cached wrapper or generates a new one.

The generated method wrapper force-casts the raw native pointer to the target Codon class, converts Python arguments into Codon values, invokes the native method, and converts the return value back to Python with `__to_py__()`.  

### 4. Field access

**NOT IMPLEMENTED** in this PR. (implement in #817)

### 5. Lifecycle management

A Python-visible jitclass instance owns a proxy, which owns a Cython handle to a native `JITClassInstance` control block. The Python API supports explicit `close()`, context-manager cleanup, and finalizer-based fallback cleanup.

The Cython handle rejects use after release and invalidates its internal pointer before calling the native release function, preventing double release during re-entrant cleanup. 

JIT engine lifecycle check is **NOT IMPLEMENTED** in this PR. (implement in #814)

### 6. GC root safety

Native Codon objects exposed through Python are protected from premature collection by an RAII GC root. Each `JITClassInstance` owns a `JITClassRoot`, which registers the raw native object pointer as a Codon GC root for as long as the Python-owned handle remains alive. 

When the native control block is deleted, the RAII root is destroyed and the object is removed from the GC root set. This ensures that a native Codon object cannot be collected while it is still reachable from Python.

**PR Stack:**
1. https://github.com/exaloop/codon/pull/813 
2. https://github.com/exaloop/codon/pull/816 ⬅
3. https://github.com/exaloop/codon/pull/814
4. https://github.com/exaloop/codon/pull/817