### PR TITLE
[GPU] fix invalid refer for device ptr in dict

### DIFF
--- a/stdlib/internal/gpu.codon
+++ b/stdlib/internal/gpu.codon
@@ -828,7 +828,7 @@ class Dict:
 
             _ptr_from_gpu(self._indices, mem._indices, indices_size)
             _ptr_from_gpu(self._active, mem._active, active_bytes)
-            _ptr_from_gpu(self._entries, mem._entries, capacity, mem._is_active)
+            _ptr_from_gpu(self._entries, mem._entries, capacity, self._is_active)
 
     def __from_gpu_new__(other: Dict[K,V]):
         mem = _object_from_gpu(other)


### PR DESCRIPTION
fixes #811 

### Summary 

This PR fixes an invalid behavior observed when using an ordered `dict` in GPU round-trip usage.

Specifically, the issue occurs when copying an `ordered dict` containing `list entries` from host to device and then back to host.

### MRE

In `kernels.codon`, the `test_conversions` workload includes a dict test with list entries:

```python
import gpu

@gpu.kernel
def copy_dict(x, out):
    out[0] = x

x = {1: [1.1], 2: [2.2]}
out = [type(x)()]

copy_dict(x, out, grid=1, block=1)
print(out == [x])

```
### Previous Behavior
With the default ordered-dict implementation, the program segfaulted:
```bash
$ codon run -release 02_gpu_dict_copy_int_list_float.codon 
Segmentation fault (core dumped)
```

However, the same workload succeeded when using unordered dicts explicitly:
```bash
$ codon run -release --unordered-dict 02_gpu_dict_copy_int_list_float.codon 
True
``` 

### Root Cause
In `gpu.codon`, during the `device-to-host transfer path`, 

the `ordered dict implementation` directly referred to a `device pointer`.

This is invalid behavior because host-side reconstruction `must not directly access device memory`. Instead, the transfer should go through the appropriate `memory class methods` and use host-side references after the required data has been copied back.

The problematic path was in Dict.__from_gpu__:

```python
@extend
class Dict:
...
    def __from_gpu__(self, other: Dict[K,V]):
...
        else:
            _ptr_from_gpu(self._indices, mem._indices, indices_size)
            _ptr_from_gpu(self._active, mem._active, active_bytes)
            _ptr_from_gpu(self._entries, mem._entries, capacity, mem._is_active) 
```
Here, `mem._is_active` referred to device-side memory during the _entries transfer.

### Changes

This PR changes the device pointer reference to use `self._is_active` instead.

This is valid because `_active` has already been transferred before `_is_active` is needed, so the host-side active-state information is available at that point.

### testing `test_conversions workload`
<img width="608" height="40" alt="image" src="https://github.com/user-attachments/assets/4334a992-49cf-4a44-bf1e-8d71bccc70bc" />

Now it work well without commenting out any workloads.

### MRE: Dict element Changes in kernel
I also tested a case where dict entries are modified inside the GPU kernel:
```python
import gpu

@gpu.kernel
def mutate_dict(x, out):
    del x[1]
    x[3] = x[2]
    out[0] = x

x = {1: [1.1], 2: [2.2]}
expected = {2: [2.2], 3: [2.2]}
out = [type(x)()]

mutate_dict(x, out, grid=1, block=1)
print(out == [expected])
```
### Result
```bash
$ codon run -release 09_gpu_dict_mutate_active_int_list_float.codon 
True
```