### PR TITLE
Python gpu dsl decorator implementation

### DIFF
--- a/codon/compiler/jit.cpp
+++ b/codon/compiler/jit.cpp
@@ -268,6 +268,15 @@ std::string buildKey(const std::string &name, const std::vector<std::string> &ty
   return key.str();
 }
 
+std::string buildGpuKey(const std::string &name, const std::vector<std::string> &types) {
+  std::stringstream key;
+  key << "gpu|" << name;
+  for (const auto &t : types) {
+    key << "|" << t;
+  }
+  return key.str();
+}
+
 std::string buildPythonWrapper(const std::string &name, const std::string &wrapname,
                                const std::vector<std::string> &types,
                                const std::string &pyModule,
@@ -297,6 +306,38 @@ std::string buildPythonWrapper(const std::string &name, const std::string &wrapn
     wrap << "py" << i;
   }
   wrap << ").__to_py__()\n";
+
+  return wrap.str();
+}
+
+std::string buildPythonWrapperGPU(const std::string &name, const std::string &wrapname,
+                                  const std::vector<std::string> &types) {
+  std::stringstream wrap;
+  const auto dataCount = types.size() - 2;
+  const auto gridIndex = types.size() - 2;
+  const auto blockIndex = types.size() - 1;
+
+  wrap << "@export\n";
+  wrap << "def " << wrapname << "(args: cobj) -> cobj:\n";
+  for (unsigned i = 0; i < dataCount; i++) {
+    wrap << "    "
+         << "a" << i << " = " << types[i] << ".__from_py__(PyTuple_GetItem(args, " << i
+         << "))\n";
+  }
+  wrap << "    grid = " << types[gridIndex]
+       << ".__from_py__(PyTuple_GetItem(args, " << gridIndex << "))\n";
+  wrap << "    block = " << types[blockIndex]
+       << ".__from_py__(PyTuple_GetItem(args, " << blockIndex << "))\n";
+  wrap << "    " << name << "(";
+  for (unsigned i = 0; i < dataCount; i++) {
+    if (i > 0)
+      wrap << ", ";
+    wrap << "a" << i;
+  }
+  if (dataCount > 0)
+    wrap << ", ";
+  wrap << "grid=grid, block=block)\n";
+  wrap << "    return None.__to_py__()\n";
 
   return wrap.str();
 }
@@ -342,6 +383,61 @@ JIT::JITResult JIT::executePython(const std::string &name,
     auto wrapper = buildPythonWrapper(name, wrapname, types, pyModule, pyVars);
     if (debug)
       fmt::print(stderr, "[codon::jit::executePython] wrapper:\n{}-----\n", wrapper);
+    if (auto err = compile(wrapper).takeError()) {
+      auto errorInfo = llvm::toString(std::move(err));
+      return JITResult::error(errorInfo);
+    }
+
+    auto *M = compiler->getModule();
+    auto *func = M->getOrRealizeFunc(wrapname, {pydata->getCObjType(M)});
+    seqassertn(func, "could not access wrapper func '{}'", wrapname);
+    cache.emplace(key, func);
+
+    auto result = address(func);
+    if (auto err = result.takeError()) {
+      auto errorInfo = llvm::toString(std::move(err));
+      return JITResult::error(errorInfo);
+    }
+    wrap = (PyWrapperFunc *)result.get();
+  }
+
+  try {
+    auto *ans = (*wrap)(arg);
+    return JITResult::success(ans);
+  } catch (const runtime::JITError &e) {
+    auto err = handleJITError(e);
+    auto errorInfo = llvm::toString(std::move(err));
+    return JITResult::error(errorInfo);
+  }
+}
+
+JIT::JITResult JIT::executePythonGPU(const std::string &name,
+                                  const std::vector<std::string> &types,
+                                  const std::string &pyModule,
+                                  const std::vector<std::string> &pyVars, void *arg,
+                                  bool debug) {
+  (void)pyModule;
+  if (types.size() < 2)
+    return JITResult::error("GPU wrapper expects data arguments followed by grid and block");
+  if (!pyVars.empty())
+    return JITResult::error("pyvars are not supported for GPU wrappers");
+
+  auto key = buildGpuKey(name, types);
+  auto &cache = pydata->cache;
+  auto it = cache.find(key);
+  PyWrapperFunc *wrap;
+
+  if (it != cache.end()) {
+    auto *wrapper = it->second;
+    const std::string name = ir::LLVMVisitor::getNameForFunction(wrapper);
+    auto func = llvm::cantFail(engine->lookup(name));
+    wrap = func.toPtr<PyWrapperFunc>();
+  } else {
+    static int idx = 0;
+    auto wrapname = "__codon_gpu_wrapped__" + name + "_" + std::to_string(idx++);
+    auto wrapper = buildPythonWrapperGPU(name, wrapname, types);
+    if (debug)
+      fmt::print(stderr, "[codon::jit::executePythonGPU] wrapper:\n{}-----\n", wrapper);
     if (auto err = compile(wrapper).takeError()) {
       auto errorInfo = llvm::toString(std::move(err));
       return JITResult::error(errorInfo);
@@ -418,4 +514,24 @@ CJITResult jit_execute_safe(void *jit, char *code, char *file, int32_t line,
 char *get_jit_library() {
   auto t = codon::ast::library_path();
   return strndup(t.c_str(), t.size());
+}
+
+CJITResult gpu_execute_python(void *jit, char *name, char **types, size_t types_size,
+                              char *pyModule, char **py_vars, size_t py_vars_size,
+                              void *arg, uint8_t debug) {
+  std::vector<std::string> cppTypes;
+  cppTypes.reserve(types_size);
+  for (size_t i = 0; i < types_size; i++)
+    cppTypes.emplace_back(types[i]);
+  std::vector<std::string> cppPyVars;
+  cppPyVars.reserve(py_vars_size);
+  for (size_t i = 0; i < py_vars_size; i++)
+    cppPyVars.emplace_back(py_vars[i]);
+  auto t = ((codon::jit::JIT *)jit)
+               ->executePythonGPU(std::string(name), cppTypes, std::string(pyModule),
+                               cppPyVars, arg, bool(debug));
+  void *result = t.result;
+  char *message =
+      t.message.empty() ? nullptr : strndup(t.message.c_str(), t.message.size());
+  return {result, message};
 }

--- a/codon/compiler/jit.cpp
+++ b/codon/compiler/jit.cpp
@@ -268,7 +268,8 @@ std::string buildKey(const std::string &name, const std::vector<std::string> &ty
   return key.str();
 }
 
-std::string buildGpuKey(const std::string &name, const std::vector<std::string> &types) {
+std::string buildGpuKey(const std::string &name,
+                        const std::vector<std::string> &types) {
   std::stringstream key;
   key << "gpu|" << name;
   for (const auto &t : types) {
@@ -324,10 +325,10 @@ std::string buildPythonWrapperGPU(const std::string &name, const std::string &wr
          << "a" << i << " = " << types[i] << ".__from_py__(PyTuple_GetItem(args, " << i
          << "))\n";
   }
-  wrap << "    grid = " << types[gridIndex]
-       << ".__from_py__(PyTuple_GetItem(args, " << gridIndex << "))\n";
-  wrap << "    block = " << types[blockIndex]
-       << ".__from_py__(PyTuple_GetItem(args, " << blockIndex << "))\n";
+  wrap << "    grid = " << types[gridIndex] << ".__from_py__(PyTuple_GetItem(args, "
+       << gridIndex << "))\n";
+  wrap << "    block = " << types[blockIndex] << ".__from_py__(PyTuple_GetItem(args, "
+       << blockIndex << "))\n";
   wrap << "    " << name << "(";
   for (unsigned i = 0; i < dataCount; i++) {
     if (i > 0)
@@ -412,13 +413,14 @@ JIT::JITResult JIT::executePython(const std::string &name,
 }
 
 JIT::JITResult JIT::executePythonGPU(const std::string &name,
-                                  const std::vector<std::string> &types,
-                                  const std::string &pyModule,
-                                  const std::vector<std::string> &pyVars, void *arg,
-                                  bool debug) {
+                                     const std::vector<std::string> &types,
+                                     const std::string &pyModule,
+                                     const std::vector<std::string> &pyVars, void *arg,
+                                     bool debug) {
   (void)pyModule;
   if (types.size() < 2)
-    return JITResult::error("GPU wrapper expects data arguments followed by grid and block");
+    return JITResult::error(
+        "GPU wrapper expects data arguments followed by grid and block");
   if (!pyVars.empty())
     return JITResult::error("pyvars are not supported for GPU wrappers");
 
@@ -529,7 +531,7 @@ CJITResult gpu_execute_python(void *jit, char *name, char **types, size_t types_
     cppPyVars.emplace_back(py_vars[i]);
   auto t = ((codon::jit::JIT *)jit)
                ->executePythonGPU(std::string(name), cppTypes, std::string(pyModule),
-                               cppPyVars, arg, bool(debug));
+                                  cppPyVars, arg, bool(debug));
   void *result = t.result;
   char *message =
       t.message.empty() ? nullptr : strndup(t.message.c_str(), t.message.size());

--- a/codon/compiler/jit.h
+++ b/codon/compiler/jit.h
@@ -102,10 +102,10 @@ public:
                         bool debug);
 
   JITResult executePythonGPU(const std::string &name,
-                          const std::vector<std::string> &types,
-                          const std::string &pyModule,
-                          const std::vector<std::string> &pyVars, void *arg,
-                          bool debug);
+                             const std::vector<std::string> &types,
+                             const std::string &pyModule,
+                             const std::vector<std::string> &pyVars, void *arg,
+                             bool debug);
   // Errors
   llvm::Error handleJITError(const runtime::JITError &e);
 };

--- a/codon/compiler/jit.h
+++ b/codon/compiler/jit.h
@@ -101,6 +101,11 @@ public:
   JITResult executeSafe(const std::string &code, const std::string &file, int line,
                         bool debug);
 
+  JITResult executePythonGPU(const std::string &name,
+                          const std::vector<std::string> &types,
+                          const std::string &pyModule,
+                          const std::vector<std::string> &pyVars, void *arg,
+                          bool debug);
   // Errors
   llvm::Error handleJITError(const runtime::JITError &e);
 };

--- a/codon/compiler/jit_extern.h
+++ b/codon/compiler/jit_extern.h
@@ -21,6 +21,10 @@ struct CJITResult jit_execute_python(void *jit, char *name, char **types,
                                      size_t types_size, char *pyModule, char **py_vars,
                                      size_t py_vars_size, void *arg, uint8_t debug);
 
+struct CJITResult gpu_execute_python(void *jit, char *name, char **types,
+                                     size_t types_size, char *pyModule, char **py_vars,
+                                     size_t py_vars_size, void *arg, uint8_t debug);
+
 struct CJITResult jit_execute_safe(void *jit, char *code, char *file, int32_t line,
                                    uint8_t debug);
 

--- a/jit/codon/__init__.py
+++ b/jit/codon/__init__.py
@@ -1,9 +1,10 @@
 # Copyright (C) 2022-2026 Exaloop Inc. <https://exaloop.io>
 
 __all__ = [
-    "jit", "gpu", "convert", "JITError", "JITWrapper", "_jit_register_fn", "_jit"
+    "jit", "gpu", "gpu_finalize", "convert", "JITError", "JITWrapper",
+    "_jit_register_fn", "_jit"
 ]
 
-from .decorator import jit, gpu, convert, execute, JITError, JITWrapper, _jit_register_fn, _jit_callback_fn, _jit
+from .decorator import jit, gpu, gpu_finalize, convert, execute, JITError, JITWrapper, _jit_register_fn, _jit_callback_fn, _jit
 
 __codon__ = False

--- a/jit/codon/__init__.py
+++ b/jit/codon/__init__.py
@@ -1,9 +1,9 @@
 # Copyright (C) 2022-2026 Exaloop Inc. <https://exaloop.io>
 
 __all__ = [
-    "jit", "convert", "JITError", "JITWrapper", "_jit_register_fn", "_jit"
+    "jit", "gpu", "convert", "JITError", "JITWrapper", "_jit_register_fn", "_jit"
 ]
 
-from .decorator import jit, convert, execute, JITError, JITWrapper, _jit_register_fn, _jit_callback_fn, _jit
+from .decorator import jit, gpu, convert, execute, JITError, JITWrapper, _jit_register_fn, _jit_callback_fn, _jit
 
 __codon__ = False

--- a/jit/codon/decorator.py
+++ b/jit/codon/decorator.py
@@ -148,6 +148,8 @@ def _codon_types(args, **kwargs):
 
 def _reset_jit():
     global _jit
+    if "_gpu_finalized" in globals():
+        globals()["_gpu_finalized"] = False
     _jit = JITWrapper()
     init_code = (
         "from internal.python import "
@@ -162,6 +164,8 @@ def _reset_jit():
     return _jit
 
 _jit = _reset_jit()
+_gpu_registry = []
+_gpu_finalized = False
 
 class RewriteFunctionArgs(ast.NodeTransformer):
     def __init__(self, args):
@@ -330,23 +334,62 @@ def execute(code, debug=0):
 
 # ------------------------- For GPU Decorators -------------------------
 
-def _parse_gpu_decorated(obj, **kwargs):
+def _parse_gpu_kernel_source(obj, **kwargs):
     obj_name, obj_str = _obj_to_str(obj, **kwargs)
-    return obj_name, "import gpu\n\n@gpu.kernel\n" + obj_str
+    return obj_name, "@gpu.kernel\n" + obj_str
 
 def _gpu_register_fn(f, pyvars, debug):
+    global _gpu_registry
+    if _gpu_finalized:
+        name = getattr(f, "__name__", "<string>")
+        raise RuntimeError(
+            f"@codon.gpu kernel '{name}' was registered after the GPU registry "
+            "was finalized. Import all GPU kernel modules before the first GPU "
+            "launch, or call codon.gpu_finalize() after imports."
+        )
+
+    obj_name, obj_str = _parse_gpu_kernel_source(f, pyvars=pyvars)
+    fn, fl = "<internal>", 1
+    if hasattr(f, "__code__"):
+        fn, fl = f.__code__.co_filename, f.__code__.co_firstlineno
+
+    _gpu_registry.append({
+        "name": obj_name,
+        "source": obj_str,
+        "filename": fn,
+        "firstlineno": fl,
+        "debug": debug,
+    })
+    return obj_name
+
+def _gpu_finalize(debug=0):
+    global _gpu_finalized
+    if _gpu_finalized:
+        return
+    if not _gpu_registry:
+        _gpu_finalized = True
+        return
+
+    source = "import gpu\n\n" + "\n\n".join(
+        entry["source"] for entry in _gpu_registry
+    )
+    batch_debug = max([debug] + [entry["debug"] for entry in _gpu_registry])
     try:
-        obj_name, obj_str = _parse_gpu_decorated(f, pyvars=pyvars)
-        fn, fl = "<internal>", 1
-        if hasattr(f, "__code__"):
-            fn, fl = f.__code__.co_filename, f.__code__.co_firstlineno
-        if debug == 2:
-            print(f"[jit_debug] execute:\n{obj_str}", file=sys.stderr)
-        _jit.execute(obj_str, fn, fl, int(debug > 0))
-        return obj_name
+        if batch_debug == 2:
+            print(f"[jit_debug] gpu registry execute:\n{source}", file=sys.stderr)
+        _jit.execute(source, "<gpu registry>", 1, int(batch_debug > 0))
+        _gpu_finalized = True
     except JITError:
         _reset_jit()
         raise
+
+def gpu_finalize(debug=0):
+    """Compile all registered @codon.gpu kernels into one GPU JIT unit."""
+    if debug is None:
+        debug = 0
+    if debug_override:
+        debug = debug_override
+    _gpu_finalize(debug)
 
 def _gpu_callback_fn(fn,
                      obj_name,
@@ -385,6 +428,7 @@ def _gpu_callback_fn(fn,
     args = (*data_args, grid, block)
 
     try:
+        _gpu_finalize(debug)
         types = _codon_types(args, debug=debug, sample_size=sample_size)
         if debug > 0:
             print("[python] {}({})".format(obj_name, list(types)), file=sys.stderr)

--- a/jit/codon/decorator.py
+++ b/jit/codon/decorator.py
@@ -327,3 +327,110 @@ def execute(code, debug=0):
     except JITError:
         _reset_jit()
         raise
+
+# ------------------------- For GPU Decorators -------------------------
+
+def _parse_gpu_decorated(obj, **kwargs):
+    obj_name, obj_str = _obj_to_str(obj, **kwargs)
+    return obj_name, "import gpu\n\n@gpu.kernel\n" + obj_str
+
+def _gpu_register_fn(f, pyvars, debug):
+    try:
+        obj_name, obj_str = _parse_gpu_decorated(f, pyvars=pyvars)
+        fn, fl = "<internal>", 1
+        if hasattr(f, "__code__"):
+            fn, fl = f.__code__.co_filename, f.__code__.co_firstlineno
+        if debug == 2:
+            print(f"[jit_debug] execute:\n{obj_str}", file=sys.stderr)
+        _jit.execute(obj_str, fn, fl, int(debug > 0))
+        return obj_name
+    except JITError:
+        _reset_jit()
+        raise
+
+def _gpu_callback_fn(fn,
+                     obj_name,
+                     module,
+                     debug=0,
+                     sample_size=5,
+                     pyvars=None,
+                     *args,
+                     **kwargs):
+    kwargs = dict(kwargs)
+    has_grid = "grid" in kwargs
+    has_block = "block" in kwargs
+
+    if has_grid or has_block:
+        if not (has_grid and has_block):
+            raise TypeError("@codon.gpu launch requires both 'grid' and 'block'")
+        grid = kwargs.pop("grid")
+        block = kwargs.pop("block")
+        data_args = args
+        data_kwargs = kwargs
+    else:
+        if len(args) < 2:
+            raise TypeError("@codon.gpu launch requires grid and block")
+        data_args = args[:-2]
+        data_kwargs = kwargs
+        grid, block = args[-2], args[-1]
+
+    if fn is not None:
+        sig = inspect.signature(fn)
+        bound_args = sig.bind(*data_args, **data_kwargs)
+        bound_args.apply_defaults()
+        data_args = tuple(bound_args.arguments[param] for param in sig.parameters)
+    else:
+        data_args = (*data_args, *data_kwargs.values())
+
+    args = (*data_args, grid, block)
+
+    try:
+        types = _codon_types(args, debug=debug, sample_size=sample_size)
+        if debug > 0:
+            print("[python] {}({})".format(obj_name, list(types)), file=sys.stderr)
+        return _jit.run_gpu_wrapper(
+            obj_name, list(types), module, list(pyvars or []), args, int(debug > 0)
+        )
+    except JITError:
+        _reset_jit()
+        raise
+
+def _gpu_str_fn(fstr, debug=0, sample_size=5, pyvars=None):
+    obj_name = _gpu_register_fn(fstr, pyvars, debug)
+
+    def wrapped(*args, **kwargs):
+        return _gpu_callback_fn(None, obj_name, "__main__", debug, sample_size,
+                                pyvars, *args, **kwargs)
+
+    return wrapped
+
+def gpu(fn=None, debug=0, sample_size=5, pyvars=None):
+    """JIT-compile a Python function as a Codon GPU kernel.
+
+    pyvars is intentionally unsupported for now because GPU kernels cannot
+    call back into the CPython runtime or use arbitrary PyObject values.
+    """
+    if debug is None:
+        debug = 0
+    if pyvars:
+        raise ArgumentError(
+            "pyvars are not supported for @codon.gpu"
+        )
+
+    if debug_override:
+        debug = debug_override
+
+    if fn and isinstance(fn, str):
+        return _gpu_str_fn(fn, debug, sample_size, pyvars)
+
+    def _decorate(f):
+        obj_name = _gpu_register_fn(f, pyvars, debug)
+
+        @functools.wraps(f)
+        def wrapped(*args, **kwargs):
+            return _gpu_callback_fn(f, obj_name, f.__module__, debug, sample_size,
+                                    pyvars, *args, **kwargs)
+
+        return wrapped
+
+    return _decorate(fn) if fn else _decorate

--- a/jit/codon/jit.pxd
+++ b/jit/codon/jit.pxd
@@ -20,3 +20,8 @@ cdef extern from "codon/compiler/jit_extern.h":
         char *pyModule, char **py_vars, size_t py_vars_size,
         void *arg, uint8_t debug
     )
+    cdef CJITResult gpu_execute_python(
+        void *jit, char *name, char **types, size_t types_size,
+        char *pyModule, char **py_vars, size_t py_vars_size,
+        void *arg, uint8_t debug
+    )

--- a/jit/codon/jit.pyx
+++ b/jit/codon/jit.pyx
@@ -76,6 +76,38 @@ cdef class JITWrapper:
                 free(c_pyvars[i])
             free(c_pyvars)
 
+    def run_gpu_wrapper(self, name: str, types: list[str], module: str, pyvars: list[str], args, debug) -> object:
+        cdef char** c_types = <char**>calloc(len(types), sizeof(char*))
+        cdef char** c_pyvars = <char**>calloc(len(pyvars), sizeof(char*))
+        if not c_types or not c_pyvars:
+            raise JITError("Cython allocation failed")
+        try:
+            for i, s in enumerate(types):
+                bytes = s.encode('utf-8')
+                c_types[i] = <char*>malloc(len(bytes) + 1)
+                strcpy(c_types[i], bytes)
+            for i, s in enumerate(pyvars):
+                bytes = s.encode('utf-8')
+                c_pyvars[i] = <char*>malloc(len(bytes) + 1)
+                strcpy(c_pyvars[i], bytes)
+
+            result = codon.jit.gpu_execute_python(
+                self.jit, name.encode('utf-8'), c_types, len(types),
+                module.encode('utf-8'), c_pyvars, len(pyvars),
+                <void *>args, <uint8_t>debug
+            )
+            if result.error is NULL:
+                return <object>result.result
+            else:
+                msg = get_free_str(result.error)
+                raise JITError(msg)
+        finally:
+            for i in range(len(types)):
+                free(c_types[i])
+            free(c_types)
+            for i in range(len(pyvars)):
+                free(c_pyvars[i])
+            free(c_pyvars)
 
 def codon_library():
     cdef char* c = codon.jit.get_jit_library()


### PR DESCRIPTION
resolves #825 

## Implementation
The implementation follows the existing Python `CPU target JIT` decorator structure where possible, but separates the GPU path where required.

Mainly:
- Adds codon.gpu decorator
- Adds GPU-specific source rewriting:
  - Python function source is rewritten into Codon GPU source using `import gpu` and `@gpu.kernel`
- Adds a dedicated GPU callback path:
  - `grid` and `block` arguments are treated as launch metadata, not normal kernel data arguments
  - so they requires specific wrapping phase:
 ```python
@export
def __codon_wrapped__f_0(args: cobj) -> cobj:
    a0 = int.__from_py__(PyTuple_GetItem(args, 0))
    a1 = int.__from_py__(PyTuple_GetItem(args, 1))
    grid = tuple.__from_py(PyTuple_GetItem(args, ..))
    block = tuple.__from_py(PyTuple_GetItem(args, ..))
    return f(a0, a1, grid=grid, block=block).__to_py__()

```
- Adds lazy GPU finalization:
  - `@codon.gpu` decorator registration stores kernel source in a registry
  - first GPU launch compiles all registered kernels as one batch implicitly calling gpu_finalized()
  - or just `codon.gpu_finalize()` can explicitly finalize before first launch

## Why GPU Needs a Seperate Path
The existing CPU wrapper path can treat every argument as a normal data parameter. 

GPU launch syntax is different because `grid` and `block` are special launch metadata.

And for IR function object to have `kernel attribute`, source re-writing is supposed to be seperated from original path. 

```
kernel(a, b, c, grid=1, block=256)
```

should compile to a wrapper that passes only a, b, and c as kernel data arguments, while using `grid` and `block` for launch configuration.

## Why Lazy Finalization (Compilation) Is Needed
Codon GPU lowering currently exposes generated PTX through the `__codon_ptx__` hook used by `gpu.codon`.

If each codon.gpu decorator immediately JIT-compiles a single kernel, only the first compiled PTX blob may be available to CUDA module loading. 

In multi-kernel Python modules, the second kernel wrapper can be generated successfully but fail at launch with:

```
CUDA_ERROR_NOT_FOUND
```

### MRE1: Multiple Kernel Def
```python
import os
import subprocess
import sys

import codon
import numpy as np


DEBUG = int(os.environ.get("CODON_JIT_CASE_DEBUG", "0"))
N = 16


@codon.gpu(debug=DEBUG)
def add_kernel(a: np.ndarray[int, 1], b: np.ndarray[int, 1], c: np.ndarray[int, 1]):
    i = gpu.thread.x
    c[i] = a[i] + b[i]


@codon.gpu(debug=DEBUG)
def scale_kernel(a: np.ndarray[int, 1], c: np.ndarray[int, 1], factor: int):
    i = gpu.thread.x
    c[i] = a[i] * factor


def fresh_arrays():
    a = np.arange(N, dtype=np.int64)
    b = np.arange(N, dtype=np.int64) * 2
    c = np.zeros(N, dtype=np.int64)
    return a, b, c


def launch_first():
    a, b, c = fresh_arrays()
    add_kernel(a, b, c, grid=1, block=N)
    print("launch_first", c.tolist())


def launch_second():
    a, _, c = fresh_arrays()
    scale_kernel(a, c, 4, grid=1, block=N)
    print("launch_second", c.tolist())


def launch_first_then_second():
    launch_first()
    launch_second()


def run_case(case):
    print("registered", add_kernel.__name__, scale_kernel.__name__)
    print("case", case)
    if case == "launch_first":
        launch_first()
    elif case == "launch_second":
        launch_second()
    elif case == "launch_first_then_second":
        launch_first_then_second()
    else:
        raise ValueError(case)


if __name__ == "__main__":
    if len(sys.argv) == 2:
        run_case(sys.argv[1])
    else:
        for case in ("launch_first", "launch_second", "launch_first_then_second"):
            print("###", case, flush=True)
            subprocess.run([sys.executable, __file__, case], check=False)
```
### Result When No Lazy Compilation
```bash
File "codon/jit.pyx", line 103, in codon.codon_jit.JITWrapper.run_gpu_wrapper
codon.codon_jit.JITError: CUDAError: /home/swchoi/src/codon/install/lib/codon/stdlib/internal/gpu.codon:124:9: named symbol not found (CUDA_ERROR_NOT_FOUND)
```
### Lazy Finalization
```bash
$ python main.py 
### launch_first
registered add_kernel scale_kernel
case launch_first
launch_first [0, 3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 36, 39, 42, 45]
### launch_second
registered add_kernel scale_kernel
case launch_second
launch_second [0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60]
### launch_first_then_second
registered add_kernel scale_kernel
case launch_first_then_second
launch_first [0, 3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 36, 39, 42, 45]
launch_second [0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60]
```

## Notes / Limitation
The Python DSL supports annotation-based GPU kernels where Codon can realize concrete GPU signatures. 

Some Codon-native host constructs from .codon tests are not directly expressible in Python syntax and remain separate concerns.

For example:

```python
@codon.gpu(debug=DEBUG)
def add_kernel(a, b, c):
    i = gpu.thread.x
    c[i] = a[i] + b[i]
```

such kernel signature can't be JIT-ed and executed. Because, such signature must be inferenced from caller signature at `gpu.codon`, `kernel_wrapper`. But what conveyed to Codon Compile Pipeline is only limited code segment with decorator, so inferencing signature phase is limited.