### PR TITLE
Patch __codon_ptx__ when no concrete GPU kernels are realized

### DIFF
--- a/codon/cir/llvm/gpu.cpp
+++ b/codon/cir/llvm/gpu.cpp
@@ -941,8 +941,10 @@ std::unique_ptr<llvm::Module> prepareGPUmodule(llvm::Module *M, Options *options
     }
   }
 
-  if (!hasKernels)
+  if (!hasKernels) {
+    patchPTXVar(M, nullptr);
     return {};
+  }
 
   std::unique_ptr<llvm::Module> clone = llvm::CloneModule(*M);
   clone->setTargetTriple(llvm::Triple::normalize(GPU_TRIPLE));


### PR DESCRIPTION
fixes #827 

## Change
The fix is intentionally placed in `gpu.cpp`, at the GPU preparation boundary.

When no concrete kernels exist (when no definition or no specialized object exists):

- no GPU module is created
- no PTX blob is emitted
- `__codon_ptx__()` is patched to null
- the stub declaration is removed

## MRE

```
$ codon build -llvm unspec.codon -o unspec.ll
$ grep -c __codon_ptx__ unspec.ll
0
```
