### PR TITLE
[GPU] exchange LLVM optimization pass apply to GPU instead of host

### DIFF
--- a/codon/cir/llvm/optimize.cpp
+++ b/codon/cir/llvm/optimize.cpp
@@ -1086,11 +1086,11 @@ void optimize(llvm::Module *module, Options *options, PluginManager *plugins) {
     gpuOptions.native = false;
     {
       TIME("llvm/gpuopt1");
-      runLLVMOptimizationPasses(module, /*plugins=*/nullptr, &gpuOptions);
+      runLLVMOptimizationPasses(GPUmodule.get(), /*plugins=*/nullptr, &gpuOptions);
     }
     {
       TIME("llvm/gpuopt2");
-      runLLVMOptimizationPasses(module, /*plugins=*/nullptr, &gpuOptions);
+      runLLVMOptimizationPasses(GPUmodule.get(), /*plugins=*/nullptr, &gpuOptions);
     }
     {
       TIME("llvm/gpu");


### PR DESCRIPTION
fixes #829

## Changes
- updates the NVPTX optimization pipeline so that `gpuopt1` and `gpuopt2` run on the prepared GPU module instead of the host module.

Before:
```
runLLVMOptimizationPasses(module, /*plugins=*/nullptr, &gpuOptions);
``` 
After:
```
runLLVMOptimizationPasses(GPUmodule.get(), /*plugins=*/nullptr, &gpuOptions);
```

## MRE
```
$ /usr/local/cuda-12.3/bin/ptxas -arch=sm_50 -v 02_gpu_exp_on_expr_with_rel.ptx -o 02_gpu_exp_on_expr_with_rel_no_mo.cubin
ptxas info    : 0 bytes gmem
ptxas info    : Compiling entry function 'exp_kernel_naver_02_0_0_std_numpy_ndarray_ndarray_0_float32_1__std_numpy_ndarray_ndarray_0_float32_1__' for 'sm_50'
ptxas info    : Function properties for exp_kernel_naver_02_0_0_std_numpy_ndarray_ndarray_0_float32_1__std_numpy_ndarray_ndarray_0_float32_1__
    8 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads
ptxas info    : Used 29 registers, 368 bytes cmem[0], 16 bytes cmem[2]
``` 

Now with release mode, codon pipeline generates valid ptx.

### Result
```bash
$ ./02_gpu_exp_on_expr 
4 array of float32
╭─────────┬─────────┬─────────┬─────────╮
│ 0.3679  │ 1.      │ 0.1353  │ 2.7183  │
╰─────────┴─────────┴─────────┴─────────╯
```
