### PR TITLE
[OMP] Lower default static schedule as non-chunk 

### DIFF
--- a/codon/parser/visitors/translate/translate.cpp
+++ b/codon/parser/visitors/translate/translate.cpp
@@ -592,6 +592,13 @@ void TranslateVisitor::visit(ForStmt *stmt) {
     bool ordered = fc->funcGenerics[1].type->getBoolStatic()->value;
     auto threads = transform((*c)[0].value);
     auto chunk = transform((*c)[1].value);
+    if (auto *id = cast<IdExpr>((*c)[1].value)) {
+      auto name = id->getValue();
+      if (name.find(".default.std.openmp.for_par") != std::string::npos &&
+          name.find("chunk_size") != std::string::npos) {
+        chunk = ctx->cache->module->getInt(-1);
+      }
+    }
     auto collapse = fc->funcGenerics[2].type->getIntStatic()->value;
     bool gpu = fc->funcGenerics[3].type->getBoolStatic()->value;
     os = std::make_unique<OMPSched>(schedule, threads, chunk, ordered, collapse, gpu);


### PR DESCRIPTION
fixes #838

## changes
- In `codon\parser\visitors\translate\translate.cpp`, `TranslateVisitor::visit(ForStmt*)`, the OpenMP decorator arguments are inspected during AST-to-CIR translation. When the `chunk_size` argument is the generated default argument variable for `std.openmp.for_par`, it is materialized as a CIR integer constant `-1`.

## MRE Result 1
```bash
$ ./24_static_round_robin_penalty
Codon static round-robin penalty: N=16777216 THREADS=4 REPS=8
@par(schedule='static') checksum: 2139095040 time: 0.0247772 bandwidth: 40.3597 GiB/s
@par(schedule='static', chunk_size=1) checksum: 2139095040 time: 0.0959074 bandwidth: 10.4267 GiB/s
@par(schedule='static', chunk_size=N//THREADS) checksum: 2139095040 time: 0.0313323 bandwidth: 31.916 GiB/s
```

## MRE Result 2
```bash
$ ./23_static_distribution
Codon static distribution: N=32 THREADS=4
@par(schedule='static') owners: 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 2 2 2 2 2 2 2 2 3 3 3 3 3 3 3 3
  thread 0 : 0 1 2 3 4 5 6 7
  thread 1 : 8 9 10 11 12 13 14 15
  thread 2 : 16 17 18 19 20 21 22 23
  thread 3 : 24 25 26 27 28 29 30 31
@par(schedule='static', chunk_size=1) owners: 0 1 2 3 0 1 2 3 0 1 2 3 0 1 2 3 0 1 2 3 0 1 2 3 0 1 2 3 0 1 2 3
  thread 0 : 0 4 8 12 16 20 24 28
  thread 1 : 1 5 9 13 17 21 25 29
  thread 2 : 2 6 10 14 18 22 26 30
  thread 3 : 3 7 11 15 19 23 27 31
@par(schedule='static', chunk_size=4) owners: 0 0 0 0 1 1 1 1 2 2 2 2 3 3 3 3 0 0 0 0 1 1 1 1 2 2 2 2 3 3 3 3
  thread 0 : 0 1 2 3 16 17 18 19
  thread 1 : 4 5 6 7 20 21 22 23
  thread 2 : 8 9 10 11 24 25 26 27
  thread 3 : 12 13 14 15 28 29 30 31
@par(schedule='static', chunk_size=N//THREADS) owners: 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 2 2 2 2 2 2 2 2 3 3 3 3 3 3 3 3
  thread 0 : 0 1 2 3 4 5 6 7
  thread 1 : 8 9 10 11 12 13 14 15
  thread 2 : 16 17 18 19 20 21 22 23
  thread 3 : 24 25 26 27 28 29 30 31
```

