### PR TITLE
[OMP] Add subtraction reduction

### DIFF
--- a/codon/cir/transform/parallel/openmp.cpp
+++ b/codon/cir/transform/parallel/openmp.cpp
@@ -183,6 +183,16 @@ struct Reduction {
       }
 
       return (*f32)(*M->getFloat(value));
+    } else if (type->is(M->getBoolType())) {
+      switch (kind) {
+      case Kind::AND:
+        return M->getBool(true);
+      case Kind::OR:
+      case Kind::XOR:
+        return M->getBool(false);
+      default:
+        return nullptr;
+      }
     }
 
     auto *init = (*type)();
@@ -431,6 +441,30 @@ struct ReductionIdentifier : public util::Operator {
     }
   }
 
+  Reduction getReductionFromTernary(Var *shared, Type *type, Value *item) {
+    auto *M = item->getModule();
+    if (!type->is(M->getBoolType()))
+      return {};
+
+    auto *ternary = cast<TernaryInstr>(item);
+    if (!ternary || !isSharedDeref(shared, ternary->getCond()))
+      return {};
+
+    if (util::isConst<bool>(ternary->getFalseValue(), false) &&
+        ternary->getTrueValue()->getType()->is(type)) {
+      Reduction reduction = {Reduction::Kind::AND, shared};
+      return reduction.getInitial() ? reduction : Reduction();
+    }
+
+    if (util::isConst<bool>(ternary->getTrueValue(), true) &&
+        ternary->getFalseValue()->getType()->is(type)) {
+      Reduction reduction = {Reduction::Kind::OR, shared};
+      return reduction.getInitial() ? reduction : Reduction();
+    }
+
+    return {};
+  }
+
   Reduction getReductionFromCall(CallInstr *v) {
     auto *M = v->getModule();
     auto *func = util::getFunc(v->getCallee());
@@ -519,7 +553,7 @@ struct ReductionIdentifier : public util::Operator {
       return reduction;
     }
 
-    return {};
+    return getReductionFromTernary(shared, type, item);
   }
 
   Reduction getReduction(Var *shared) {

--- a/codon/cir/transform/parallel/openmp.cpp
+++ b/codon/cir/transform/parallel/openmp.cpp
@@ -98,6 +98,7 @@ struct Reduction {
   enum Kind {
     NONE,
     ADD,
+    SUB,
     MUL,
     AND,
     OR,
@@ -125,6 +126,8 @@ struct Reduction {
       switch (kind) {
       case Kind::ADD:
         return M->getInt(0);
+      case Kind::SUB:
+        return M->getInt(0);
       case Kind::MUL:
         return M->getInt(1);
       case Kind::AND:
@@ -144,6 +147,8 @@ struct Reduction {
       switch (kind) {
       case Kind::ADD:
         return M->getFloat(0.);
+      case Kind::SUB:
+        return M->getFloat(0.);
       case Kind::MUL:
         return M->getFloat(1.);
       case Kind::MIN:
@@ -159,6 +164,9 @@ struct Reduction {
 
       switch (kind) {
       case Kind::ADD:
+        value = 0.0;
+        break;
+      case Kind::SUB:
         value = 0.0;
         break;
       case Kind::MUL:
@@ -189,6 +197,9 @@ struct Reduction {
     Value *result = nullptr;
     switch (kind) {
     case Kind::ADD:
+      result = *lhs + *arg;
+      break;
+    case Kind::SUB:
       result = *lhs + *arg;
       break;
     case Kind::MUL:
@@ -230,6 +241,9 @@ struct Reduction {
     if (util::isInt(type)) {
       switch (kind) {
       case Kind::ADD:
+        func = "_atomic_int_add";
+        break;
+      case Kind::SUB:
         func = "_atomic_int_add";
         break;
       case Kind::MUL:
@@ -275,6 +289,9 @@ struct Reduction {
       case Kind::ADD:
         func = "_atomic_float32_add";
         break;
+      case Kind::SUB:
+        func = "_atomic_float32_add";
+        break;
       case Kind::MUL:
         func = "_atomic_float32_mul";
         break;
@@ -298,6 +315,9 @@ struct Reduction {
 
     switch (kind) {
     case Kind::ADD:
+      func = "__atomic_add__";
+      break;
+    case Kind::SUB:
       func = "__atomic_add__";
       break;
     case Kind::MUL:
@@ -440,6 +460,7 @@ struct ReductionIdentifier : public util::Operator {
 
     const std::vector<ReductionFunction> reductionFunctions = {
         {Module::ADD_MAGIC_NAME, Reduction::Kind::ADD, true},
+        {Module::SUB_MAGIC_NAME, Reduction::Kind::SUB, true},
         {Module::MUL_MAGIC_NAME, Reduction::Kind::MUL, true},
         {Module::AND_MAGIC_NAME, Reduction::Kind::AND, true},
         {Module::OR_MAGIC_NAME, Reduction::Kind::OR, true},

--- a/codon/cir/transform/parallel/openmp.cpp
+++ b/codon/cir/transform/parallel/openmp.cpp
@@ -441,23 +441,86 @@ struct ReductionIdentifier : public util::Operator {
     }
   }
 
+  bool isSharedDerefForReductionCond(Var *shared, Value *v) {
+    if (isSharedDeref(shared, v))
+      return true;
+
+    // Only unwrap the known lowering artifact:
+    // flow(series(assign tmp = shared_deref), tmp)
+    if (auto *flow = cast<FlowInstr>(v)) {
+      auto *series = cast<SeriesFlow>(flow->getFlow());
+      auto *ret = cast<VarValue>(flow->getValue());
+      if (!series || !ret || std::distance(series->begin(), series->end()) != 1)
+        return false;
+
+      auto *assign = cast<AssignInstr>(series->front());
+      if (!assign || assign->getLhs()->getId() != ret->getVar()->getId())
+        return false;
+
+      return isSharedDeref(shared, assign->getRhs());
+    }
+
+    return false;
+  }
+
+  static Var *getConditionResultVar(Value *v) {
+    if (auto *flow = cast<FlowInstr>(v))
+      if (auto *ret = cast<VarValue>(flow->getValue()))
+        return ret->getVar();
+
+    if (auto *ret = cast<VarValue>(v))
+      return ret->getVar();
+
+    return nullptr;
+  }
+
+  static bool isConditionResult(Value *cond, Value *v) {
+    auto *condVar = getConditionResultVar(cond);
+    auto *valueVar = cast<VarValue>(v);
+    return condVar && valueVar && condVar->getId() == valueVar->getVar()->getId();
+  }
+
+  static bool isLogicalFalseValue(Value *cond, Value *v) {
+    return util::isConst<bool>(v, false) || isConditionResult(cond, v);
+  }
+
+  static bool isLogicalTrueValue(Value *cond, Value *v) {
+    return util::isConst<bool>(v, true) || isConditionResult(cond, v);
+  }
+
   Reduction getReductionFromTernary(Var *shared, Type *type, Value *item) {
     auto *M = item->getModule();
     if (!type->is(M->getBoolType()))
       return {};
 
     auto *ternary = cast<TernaryInstr>(item);
-    if (!ternary || !isSharedDeref(shared, ternary->getCond()))
+    if (!ternary)
       return {};
 
-    if (util::isConst<bool>(ternary->getFalseValue(), false) &&
+    auto *cond = ternary->getCond();
+
+    if (isSharedDerefForReductionCond(shared, cond) &&
+        isLogicalFalseValue(cond, ternary->getFalseValue()) &&
         ternary->getTrueValue()->getType()->is(type)) {
       Reduction reduction = {Reduction::Kind::AND, shared};
       return reduction.getInitial() ? reduction : Reduction();
     }
 
-    if (util::isConst<bool>(ternary->getTrueValue(), true) &&
+    if (isSharedDerefForReductionCond(shared, cond) &&
+        isLogicalTrueValue(cond, ternary->getTrueValue()) &&
         ternary->getFalseValue()->getType()->is(type)) {
+      Reduction reduction = {Reduction::Kind::OR, shared};
+      return reduction.getInitial() ? reduction : Reduction();
+    }
+
+    if (isSharedDerefForReductionCond(shared, ternary->getTrueValue()) &&
+        isLogicalFalseValue(cond, ternary->getFalseValue())) {
+      Reduction reduction = {Reduction::Kind::AND, shared};
+      return reduction.getInitial() ? reduction : Reduction();
+    }
+
+    if (isSharedDerefForReductionCond(shared, ternary->getFalseValue()) &&
+        isLogicalTrueValue(cond, ternary->getTrueValue())) {
       Reduction reduction = {Reduction::Kind::OR, shared};
       return reduction.getInitial() ? reduction : Reduction();
     }

--- a/test/transform/omp.codon
+++ b/test/transform/omp.codon
@@ -16,6 +16,13 @@ class A:
     def __atomic_add__(a: Ptr[A], other: A):
         with lock:
             a[0] = A(a[0].n + other.n)
+    
+    def __sub__(self, other: A):
+        return A(self.n - other.n)
+        
+    def __atomic_sub__(a: Ptr[A], other: A):
+        with lock:
+            a[0] = A(a[0].n - other.n)
 
 @test
 def test_omp_api():
@@ -255,6 +262,9 @@ class Vector:
     def __add__(self, other: Vector):
         return Vector(self.x + other.x, self.y + other.y)
 
+    def __sub__(self, other: Vector):
+        return Vector(self.x - other.x, self.y - other.y)
+
     def __str__(self):
         return f'<{self.x}, {self.y}>'
 
@@ -276,6 +286,12 @@ def test_omp_reductions():
     for i in L:
         a += i
     assert a == expected(N, 0, int.__add__)
+
+    a = 0
+    @par
+    for i in L:
+        a -= i
+    assert a == expected(N, 0, int.__sub__)
 
     a = 0
     @par
@@ -327,6 +343,19 @@ def test_omp_reductions():
     for i in L:
         a += i
     assert a == expected(N, 0, int.__add__)
+    
+    x = A(0)
+    @par
+    for i in L:
+        x -= A(i)
+    assert x.n == expected(N, 0, int.__sub__)
+
+    # static chunked
+    a = 0
+    @par(chunk_size=3)
+    for i in L:
+        a -= i
+    assert a == expected(N, 0, int.__sub__)
 
     a = 0
     @par(chunk_size=3)
@@ -371,6 +400,12 @@ def test_omp_reductions():
     for i in L:
         x += A(i)
     assert x.n == expected(N, 0, int.__add__)
+    
+    x = A(0)
+    @par(chunk_size=3)
+    for i in L:
+        x -= A(i)
+    assert x.n == expected(N, 0, int.__sub__)
 
     # dynamic
     a = 0
@@ -382,6 +417,12 @@ def test_omp_reductions():
     a = 0
     @par(schedule='dynamic')
     for i in L:
+        a -= i
+    assert a == expected(N, 0, int.__sub__)
+
+    a = 0
+    @par(schedule='dynamic')
+    for i in L:
         a |= i
     assert a == expected(N, 0, int.__or__)
 
@@ -423,12 +464,24 @@ def test_omp_reductions():
         x += A(i)
     assert x.n == expected(N, 0, int.__add__)
 
+    x = A(0)
+    @par(schedule='dynamic')
+    for i in L:
+        x -= A(i)
+    assert x.n == expected(N, 0, int.__sub__)
+
     # floats
     c = 0.
     @par
     for i in L:
         c += float(i)
     assert c == expected(N, 0., float.__add__)
+
+    c = 0.
+    @par
+    for i in L:
+        c -= float(i)
+    assert c == expected(N, 0., float.__sub__)
 
     c = 1.
     @par
@@ -462,6 +515,18 @@ def test_omp_reductions():
         c = i + c  # int-float op
     assert c == expected(N, 0., float.__add__)
 
+    c = 0.
+    @par
+    for i in L:
+        c -= i  # float-int op
+    assert c == expected(N, 0., float.__sub__)
+
+    c = 0.
+    @par
+    for i in L:
+        c = c - i  # float-int op
+    assert c == expected(N, 0., float.__sub__)
+
     # float32s
     c = f32(0.)
     # this one can give different results due to
@@ -470,6 +535,12 @@ def test_omp_reductions():
     for i in L[1:1001]:
         c += f32(i)
     assert c == sum((f32(i) for i in range(1001)), f32(0))
+
+    c = f32(0.)
+    @par
+    for i in L[1:1001]:
+        c -= f32(i)
+    assert c == sum((-f32(i) for i in range(1001)), f32(0))
 
     c = f32(1.)
     @par
@@ -503,16 +574,31 @@ def test_omp_reductions():
         c = i + c  # int-float op
     assert c == f32(1+2+3+4+5+6+7+8+9+10+11)
 
+    c = f32(0.)
+    @par
+    for i in L[:12]:
+        c -= i  # float-int op
+    assert c == f32(-1-2-3-4-5-6-7-8-9-10-11)
+
+    c = f32(0.)
+    @par
+    for i in L[:12]:
+        c = c - i  # int-float op
+    assert c == f32(0-1-2-3-4-5-6-7-8-9-10-11)
+
     x_add = 10.
+    x_sub = 10.
     x_min = inf
     x_max = -inf
     @par
     for i in L:
         x_i = float(i)
         x_add += x_i
+        x_sub -= x_i
         x_min = min(x_min, x_i)
         x_max = max(x_i, x_max)
     assert x_add == expected(N, 10., float.__add__)
+    assert x_sub == expected(N, 10., float.__sub__)
     assert x_min == expected(N, inf, min)
     assert x_max == expected(N, -inf, max)
 
@@ -528,23 +614,31 @@ def test_omp_reductions():
     g = my_global
     a = 0
     b = 0
+    c = 0
     @par(schedule='dynamic', num_threads=3)
     for i in L:
         a += i
-        b ^= i
+        b -= i
+        c ^= i
         my_global += i
     assert a == expected(N, 0, int.__add__)
-    assert b == expected(N, 0, int.__xor__)
+    assert b == expected(N, 0, int.__sub__)
+    assert c == expected(N, 0, int.__xor__)
     assert my_global == g + expected(N, 0, int.__add__)
 
     # custom reductions
     vectors = [Vector(i, i) for i in range(10)]
-    v = Vector()
+    v_add = Vector()
+    v_sub = Vector()
+    
     @par
     for vv in vectors:
-        v += vv
-    assert v.x == 45.0
-    assert v.y == 45.0
+        v_add += vv
+        v_sub -= vv
+    assert v_add.x == 45.0
+    assert v_add.y == 45.0
+    assert v_sub.x == -45.0
+    assert v_sub.y == -45.0
 
 another_global = 0
 @test

--- a/test/transform/omp.codon
+++ b/test/transform/omp.codon
@@ -311,6 +311,30 @@ def test_omp_reductions():
         a &= i
     assert a == expected(N, 0xffffffff, int.__and__)
 
+    a = True
+    @par
+    for i in L:
+        a = a and (i != N//2)
+    assert not a
+
+    a = False
+    @par
+    for i in L:
+        a = a or (i == N//2)
+    assert a
+
+    a = True
+    @par
+    for i in L:
+        a = (i != N//2) and a
+    assert not a
+
+    a = False
+    @par
+    for i in L:
+        a = (i == N//2) or a
+    assert a
+
     a = 1
     @par
     for i in L:
@@ -368,6 +392,30 @@ def test_omp_reductions():
     for i in L:
         a ^= i
     assert a == expected(N, 0, int.__xor__)
+
+    a = True
+    @par(chunk_size=3)
+    for i in L:
+        a = a and (i != N//2)
+    assert not a
+
+    a = False
+    @par(chunk_size=3)
+    for i in L:
+        a = a or (i == N//2)
+    assert a
+
+    a = True
+    @par(chunk_size=3)
+    for i in L:
+        a = (i != N//2) and a
+    assert not a
+
+    a = False
+    @par(chunk_size=3)
+    for i in L:
+        a = (i == N//2) or a
+    assert a
 
     a = 0xffffffff
     @par(chunk_size=3)
@@ -438,6 +486,30 @@ def test_omp_reductions():
         a &= i
     assert a == expected(N, 0xffffffff, int.__and__)
 
+    a = True
+    @par(schedule='dynamic')
+    for i in L:
+        a = a and (i != N//2)
+    assert not a
+
+    a = False
+    @par(schedule='dynamic')
+    for i in L:
+        a = a or (i == N//2)
+    assert a
+
+    a = True
+    @par(schedule='dynamic')
+    for i in L:
+        a = (i != N//2) and a
+    assert not a
+
+    a = False
+    @par(schedule='dynamic')
+    for i in L:
+        a = (i == N//2) or a
+    assert a
+    
     a = 1
     @par(schedule='dynamic')
     for i in L[1:10]:


### PR DESCRIPTION
fixes partially issue #840 
## Change
The change adds subtraction handling to the OpenMP reduction path, including:

- `Reduction::Kind::SUB`
- subtraction reduction initializer
- detection of subtraction RHS patterns
- final reduction combination semantics

### MRE Result

```bash
$ codon run -release mre_loop_reduction_subtract.codon 
serial expected = 0
parallel actual = 0
PASS: subtraction reduction matches serial
```
