### PR TITLE
Normalize LLVM target options before lowering

### DIFF
--- a/codon/cir/llvm/llvisitor.cpp
+++ b/codon/cir/llvm/llvisitor.cpp
@@ -238,12 +238,16 @@ llvm::Function *LLVMVisitor::getFunc(const Func *func) {
 
 std::unique_ptr<llvm::Module> LLVMVisitor::makeModule(llvm::LLVMContext &context,
                                                       const SrcInfo *src) {
+  std::string err;
   auto builder = llvm::EngineBuilder();
-  builder.setMArch(llvm::codegen::getMArch());
-  builder.setMCPU(llvm::codegen::getCPUStr());
-  builder.setMAttrs(llvm::codegen::getFeatureList());
-
+  builder.setErrorStr(&err);
+  builder.setMArch(options->march);
+  builder.setMCPU(options->mcpu);
+  builder.setMAttrs(options->mattrs);
   auto target = builder.selectTarget();
+  if (!target) {
+    compilationError(err.empty() ? "could not select LLVM target" : err);
+  }
   auto M = std::make_unique<llvm::Module>("codon", context);
   M->setTargetTriple(target->getTargetTriple().str());
   M->setDataLayout(target->createDataLayout());
@@ -378,7 +382,8 @@ void LLVMVisitor::writeToObjectFile(const std::string &filename, bool pic,
     compilationError(err.message());
   auto *os = &out->os();
 
-  auto machine = getTargetMachine(M.get(), /*setFunctionAttributes=*/false, pic);
+  auto machine =
+      getTargetMachine(M.get(), options, /*setFunctionAttributes=*/false, pic);
   auto *mmiwp = new llvm::MachineModuleInfoWrapperPass(machine.get());
   llvm::legacy::PassManager pm;
 

--- a/codon/cir/llvm/optimize.cpp
+++ b/codon/cir/llvm/optimize.cpp
@@ -14,36 +14,49 @@ static llvm::codegen::RegisterCodeGenFlags CFG;
 
 namespace codon {
 namespace ir {
+namespace {
+std::string getFeaturesStr(const std::vector<std::string> &mattrs) {
+  llvm::SubtargetFeatures features;
+  for (const auto &mattr : mattrs)
+    features.AddFeature(mattr);
+  return features.getString();
+}
+} // namespace
 
 std::unique_ptr<llvm::TargetMachine>
 getTargetMachine(llvm::Triple triple, llvm::StringRef cpuStr,
-                 llvm::StringRef featuresStr, const llvm::TargetOptions &options,
-                 bool pic) {
+                 llvm::StringRef featuresStr, const llvm::TargetOptions &targetOptions,
+                 llvm::StringRef march, bool pic) {
   std::string err;
-  const llvm::Target *target =
-      llvm::TargetRegistry::lookupTarget(llvm::codegen::getMArch(), triple, err);
+  const llvm::Target *target = llvm::TargetRegistry::lookupTarget(march, triple, err);
 
   if (!target)
     return nullptr;
 
-  return std::unique_ptr<llvm::TargetMachine>(target->createTargetMachine(
-      triple.getTriple(), cpuStr, featuresStr, options,
+  auto *tm = target->createTargetMachine(
+      triple.getTriple(), cpuStr, featuresStr, targetOptions,
       pic ? llvm::Reloc::Model::PIC_ : llvm::codegen::getExplicitRelocModel(),
-      llvm::codegen::getExplicitCodeModel(), llvm::CodeGenOptLevel::Aggressive));
+      llvm::codegen::getExplicitCodeModel(), llvm::CodeGenOptLevel::Aggressive);
+  if (!tm)
+    compilationError("could not create LLVM target machine");
+  return std::unique_ptr<llvm::TargetMachine>(tm);
 }
 
-std::unique_ptr<llvm::TargetMachine>
-getTargetMachine(llvm::Module *module, bool setFunctionAttributes, bool pic) {
+std::unique_ptr<llvm::TargetMachine> getTargetMachine(llvm::Module *module,
+                                                      Options *options,
+                                                      bool setFunctionAttributes,
+                                                      bool pic) {
   llvm::Triple moduleTriple(module->getTargetTriple());
   std::string cpuStr, featuresStr;
-  const llvm::TargetOptions options =
+  const llvm::TargetOptions targetOptions =
       llvm::codegen::InitTargetOptionsFromCodeGenFlags(moduleTriple);
   llvm::TargetLibraryInfoImpl tlii(moduleTriple);
 
   if (moduleTriple.getArch()) {
-    cpuStr = llvm::codegen::getCPUStr();
-    featuresStr = llvm::codegen::getFeaturesStr();
-    auto machine = getTargetMachine(moduleTriple, cpuStr, featuresStr, options);
+    cpuStr = options->mcpu;
+    featuresStr = getFeaturesStr(options->mattrs);
+    auto machine = getTargetMachine(moduleTriple, cpuStr, featuresStr, targetOptions,
+                                    options->march, pic);
     if (setFunctionAttributes)
       llvm::codegen::setFunctionAttributes(cpuStr, featuresStr, *module);
     return machine;
@@ -1057,7 +1070,7 @@ void runLLVMOptimizationPasses(llvm::Module *module, PluginManager *plugins,
   llvm::CGSCCAnalysisManager cgam;
   llvm::ModuleAnalysisManager mam;
   auto machine = options->native
-                     ? getTargetMachine(module, /*setFunctionAttributes=*/true)
+                     ? getTargetMachine(module, options, /*setFunctionAttributes=*/true)
                      : std::unique_ptr<llvm::TargetMachine>();
   llvm::PassBuilder pb(machine.get());
 

--- a/codon/cir/llvm/optimize.h
+++ b/codon/cir/llvm/optimize.h
@@ -13,12 +13,12 @@ namespace ir {
 
 std::unique_ptr<llvm::TargetMachine>
 getTargetMachine(llvm::Triple triple, llvm::StringRef cpuStr,
-                 llvm::StringRef featuresStr, const llvm::TargetOptions &options,
-                 bool pic = false);
+                 llvm::StringRef featuresStr, const llvm::TargetOptions &targetOptions,
+                 llvm::StringRef march, bool pic = false);
 
 std::unique_ptr<llvm::TargetMachine>
-getTargetMachine(llvm::Module *module, bool setFunctionAttributes = false,
-                 bool pic = false);
+getTargetMachine(llvm::Module *module, Options *options,
+                 bool setFunctionAttributes = false, bool pic = false);
 
 void optimize(llvm::Module *module, Options *options, PluginManager *plugins = nullptr);
 

--- a/codon/compiler/engine.cpp
+++ b/codon/compiler/engine.cpp
@@ -10,9 +10,9 @@ namespace jit {
 
 Engine::Engine(Options *options) : jit(), debug(nullptr), options(options) {
   auto eb = llvm::EngineBuilder();
-  eb.setMArch(llvm::codegen::getMArch());
-  eb.setMCPU(llvm::codegen::getCPUStr());
-  eb.setMAttrs(llvm::codegen::getFeatureList());
+  eb.setMArch(options->march);
+  eb.setMCPU(options->mcpu);
+  eb.setMAttrs(options->mattrs);
 
   auto target = eb.selectTarget();
   auto layout = target->createDataLayout();

--- a/codon/compiler/options.cpp
+++ b/codon/compiler/options.cpp
@@ -2,7 +2,9 @@
 
 #include "options.h"
 
+#include "llvm/CodeGen/CommandFlags.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/TargetParser/Host.h"
 
 namespace codon {
 namespace {
@@ -113,6 +115,21 @@ void apply(Options *opt) {
   opt->gpuFeat = GpuFeatures;
   opt->gpuOutput = PTXOutput;
   opt->log = Log;
+  opt->march = llvm::codegen::getMArch();
+  opt->mcpu = llvm::codegen::getCPUStr();
+  opt->mattrs = llvm::codegen::getFeatureList();
+  if (opt->march == "native") {
+    opt->march.clear();
+    if (opt->mcpu.empty()) {
+      auto hostCPU = llvm::sys::getHostCPUName();
+      if (!hostCPU.empty() && hostCPU != "generic")
+        opt->mcpu = std::string(hostCPU);
+    }
+    if (opt->mattrs.empty()) {
+      for (const auto &[feature, enabled] : llvm::sys::getHostCPUFeatures())
+        opt->mattrs.push_back((enabled ? "+" : "-") + feature.str());
+    }
+  }
 }
 } // namespace
 

--- a/codon/compiler/options.h
+++ b/codon/compiler/options.h
@@ -83,6 +83,15 @@ struct Options {
   /// log flags (https://docs.exaloop.io/start/usage/#logging)
   std::string log;
 
+  /// target architecture (e.g. x86_64, aarch64, etc.)
+  std::string march;
+
+  /// target CPU (e.g. skylake, cortex-a72, etc.)
+  std::string mcpu;
+
+  /// target features (e.g. +sse4.2, +neon, etc.)
+  std::vector<std::string> mattrs;
+
   /// Get a default-options instance.
   /// @return default options instance
   static std::unique_ptr<Options> getDefault(const std::string &argv0);


### PR DESCRIPTION
fixes #833
@arshajii 

## Changes
This PR normalizes LLVM codegen target options at the Codon compiler option layer instead of reading LLVM command-line flags directly from later LLVM lowering/codegen paths.

In particular:

- stores `march`, `mcpu`, and `mattrs` in Codon compiler options
- normalizes `--march=native` before it reaches LLVM target selection
- updates LLVM lowering/codegen paths to consume Codon `Options` instead of repeatedly calling LLVM global command-line accessors such as `llvm::codegen::getMArch()`
- prevents the literal string `"native"` from being passed directly to `llvm::EngineBuilder::setMArch()`

## Problem State

issue #833 is not caused by generated LLVM IR or runtime behavior. 

The crash happens while constructing the LLVM module, before LLVM IR dumping succeeds.

`EngineBuilder::selectTarget()` treats `non-empty MArch` as a registered `LLVM target name`.
 
`native` is not itself a registered target name such as `x86-64`, so target selection returns nullptr. 

Codon then dereferences that null target later in `makeModule()`.

## Why this complicated implementation

A smaller local workaround is possible in the consumer path (in `llvisitor`, `optimize`) for example:
```
if (march == "native")
  march.clear();
```
I intentionally did not keep the fix local to `llvisitor.cpp`. 

I have a [branch](https://github.com/exaloop/codon/compare/develop...BI71317:codon:pr-comp-march_native-segfault) with that simpler experiment if it is useful for comparison, but it leaves the larger issue in place.

Before this change, the option flow effectively looked like this:
```

             argv
              |
        llvm::cl parser
        /             \
Codon llvm::cl opts   LLVM CodeGen llvm::cl opts
        |             |
 Codon Options        llvm::codegen::getMArch()
        |             |
        |        llvisitor / optimize / engine
        \_____________/
              |
        compiler pipeline
```

That means multiple lower-level compiler paths independently read LLVM global command-line state. 

This makes option behavior harder to reason about and easier to accidentally diverge.

This PR moves the target option ownership into the Codon option layer:
```
argv
 |
llvm::cl parser
 |
Options::apply()
  - getMArch()
  - getCPUStr()
  - getFeatureList()
  - normalize native
 |
Codon Options
 |
llvisitor / optimize / engine
 |
LLVM APIs

```

The intent is that command-line interpretation and normalization happen once, near option parsing, and the rest of the compiler consumes already-normalized Codon compiler options.

## MRE Result
Each branch (this pr branch and [this one.](https://github.com/exaloop/codon/compare/develop...BI71317:codon:pr-comp-march_native-segfault)) makes no more segfaults.
<img width="983" height="38" alt="스크린샷 2026-07-28 142743" src="https://github.com/user-attachments/assets/b9e598e9-0dbc-4874-a39e-d4c77a926e1d" />

