### PR TITLE
[Co-Routine] Avoid materializing zero-sized LLVM values through storage paths

### DIFF
--- a/codon/cir/llvm/llvisitor.cpp
+++ b/codon/cir/llvm/llvisitor.cpp
@@ -129,8 +129,8 @@ void LLVMVisitor::registerGlobal(const Var *var) {
     insertFunc(f, makeLLVMFunction(f));
   } else {
     auto *llvmType = getLLVMType(var->getType());
-    if (llvmType->isVoidTy()) {
-      insertVar(var, getDummyVoidValue());
+    if (!isStorableType(llvmType)) {
+      insertVar(var, getDummyValue(llvmType));
     } else {
       bool external = var->isExternal();
       bool tls = var->isThreadLocal();
@@ -1764,8 +1764,8 @@ void LLVMVisitor::visit(const InternalFunc *x) {
   if (internalFuncMatches<GeneratorType, GeneratorType>("__promise__", x)) {
     auto *generatorType = cast<GeneratorType>(parentType);
     auto *baseType = getLLVMType(generatorType->getBase());
-    if (baseType->isVoidTy()) {
-      result = llvm::ConstantPointerNull::get(B->getVoidTy()->getPointerTo());
+    if (!isStorableType(baseType)) {
+      result = getDummyValue(baseType);
     } else {
       llvm::FunctionCallee coroPromise =
           llvm::Intrinsic::getDeclaration(M.get(), llvm::Intrinsic::coro_promise);
@@ -1939,21 +1939,29 @@ void LLVMVisitor::visit(const BodiedFunc *x) {
   auto argIter = func->arg_begin();
   for (auto varIter = x->arg_begin(); varIter != x->arg_end(); ++varIter) {
     const Var *var = *varIter;
-    auto *storage = B->CreateAlloca(getLLVMType(var->getType()));
-    B->CreateStore(argIter, storage);
-    insertVar(var, storage);
+    auto *llvmType = getLLVMType(var->getType());
+    llvm::Value *storage = nullptr;
+    if (isStorableType(llvmType)) {
+      storage = B->CreateAlloca(llvmType);
+      B->CreateStore(argIter, storage);
+      insertVar(var, storage);
+    } else {
+      insertVar(var, getDummyValue(llvmType));
+    }
 
     // debug info
-    auto *srcInfo = getSrcInfo(var);
-    auto *file = db.getFile(srcInfo->file);
-    auto *scope = func->getSubprogram();
-    auto *debugVar = db.builder->createParameterVariable(
-        scope, getDebugNameForVariable(var), argIdx, file, srcInfo->line,
-        getDIType(var->getType()), options->debug);
-    db.builder->insertDeclare(
-        storage, debugVar, db.builder->createExpression(),
-        llvm::DILocation::get(*context, srcInfo->line, srcInfo->col, scope),
-        entryBlock);
+    if (storage) {
+      auto *srcInfo = getSrcInfo(var);
+      auto *file = db.getFile(srcInfo->file);
+      auto *scope = func->getSubprogram();
+      auto *debugVar = db.builder->createParameterVariable(
+          scope, getDebugNameForVariable(var), argIdx, file, srcInfo->line,
+          getDIType(var->getType()), options->debug);
+      db.builder->insertDeclare(
+          storage, debugVar, db.builder->createExpression(),
+          llvm::DILocation::get(*context, srcInfo->line, srcInfo->col, scope),
+          entryBlock);
+    }
 
     ++argIter;
     ++argIdx;
@@ -1961,8 +1969,8 @@ void LLVMVisitor::visit(const BodiedFunc *x) {
 
   for (auto *var : *x) {
     auto *llvmType = getLLVMType(var->getType());
-    if (llvmType->isVoidTy()) {
-      insertVar(var, getDummyVoidValue());
+    if (!isStorableType(llvmType)) {
+      insertVar(var, getDummyValue(llvmType));
     } else {
       auto *storage = B->CreateAlloca(llvmType);
       insertVar(var, storage);
@@ -2084,10 +2092,15 @@ void LLVMVisitor::visit(const VarValue *x) {
   } else {
     auto *varPtr = getVar(x->getVar());
     seqassertn(varPtr, "{} value not found", *x);
+    auto *llvmType = getLLVMType(x->getType());
+    if (!isStorableType(llvmType)) {
+      value = getDummyValue(llvmType);
+      return;
+    }
     B->SetInsertPoint(block);
     if (x->getVar()->isThreadLocal())
       varPtr = B->CreateThreadLocalAddress(varPtr);
-    value = B->CreateLoad(getLLVMType(x->getType()), varPtr);
+    value = B->CreateLoad(llvmType, varPtr);
   }
 }
 
@@ -2129,6 +2142,16 @@ void LLVMVisitor::visit(const PointerValue *x) {
   }
 
   value = B->CreateInBoundsGEP(getLLVMType(x->getVar()->getType()), var, gepIndices);
+}
+
+bool LLVMVisitor::isStorableType(llvm::Type *type) {
+  return !type->isVoidTy() && M->getDataLayout().getTypeAllocSize(type) != 0;
+}
+
+llvm::Value *LLVMVisitor::getDummyValue(llvm::Type *type) {
+  if (type->isVoidTy())
+    return getDummyVoidValue();
+  return llvm::UndefValue::get(type);
 }
 
 /*
@@ -2557,7 +2580,7 @@ void LLVMVisitor::visit(const ForFlow *x) {
   auto *done = B->CreateCall(coroDone, iter);
   B->CreateCondBr(done, cleanupBlock, bodyBlock);
 
-  if (!loopVarType->isVoidTy()) {
+  if (isStorableType(loopVarType)) {
     B->SetInsertPoint(bodyBlock);
     auto *alignment =
         B->getInt32(M->getDataLayout().getPrefTypeAlign(loopVarType).value());
@@ -3125,7 +3148,7 @@ void LLVMVisitor::visit(const AssignInstr *x) {
   auto *var = getVar(x->getLhs());
   seqassertn(var, "could not find {} var", *x->getLhs());
   process(x->getRhs());
-  if (var != getDummyVoidValue()) {
+  if (isStorableType(getLLVMType(x->getLhs()->getType()))) {
     B->SetInsertPoint(block);
     if (x->getLhs()->isThreadLocal())
       var = B->CreateThreadLocalAddress(var);

--- a/codon/cir/llvm/llvisitor.cpp
+++ b/codon/cir/llvm/llvisitor.cpp
@@ -1941,12 +1941,10 @@ void LLVMVisitor::visit(const BodiedFunc *x) {
     const Var *var = *varIter;
     auto *llvmType = getLLVMType(var->getType());
     llvm::Value *storage = nullptr;
+    storage = B->CreateAlloca(llvmType);
+    insertVar(var, storage);
     if (isStorableType(llvmType)) {
-      storage = B->CreateAlloca(llvmType);
       B->CreateStore(argIter, storage);
-      insertVar(var, storage);
-    } else {
-      insertVar(var, getDummyValue(llvmType));
     }
 
     // debug info
@@ -1969,7 +1967,7 @@ void LLVMVisitor::visit(const BodiedFunc *x) {
 
   for (auto *var : *x) {
     auto *llvmType = getLLVMType(var->getType());
-    if (!isStorableType(llvmType)) {
+    if (llvmType->isVoidTy()) {
       insertVar(var, getDummyValue(llvmType));
     } else {
       auto *storage = B->CreateAlloca(llvmType);

--- a/codon/cir/llvm/llvisitor.cpp
+++ b/codon/cir/llvm/llvisitor.cpp
@@ -1764,8 +1764,8 @@ void LLVMVisitor::visit(const InternalFunc *x) {
   if (internalFuncMatches<GeneratorType, GeneratorType>("__promise__", x)) {
     auto *generatorType = cast<GeneratorType>(parentType);
     auto *baseType = getLLVMType(generatorType->getBase());
-    if (!isStorableType(baseType)) {
-      result = getDummyValue(baseType);
+    if (baseType->isVoidTy()) {
+      result = llvm::ConstantPointerNull::get(B->getVoidTy()->getPointerTo());
     } else {
       llvm::FunctionCallee coroPromise =
           llvm::Intrinsic::getDeclaration(M.get(), llvm::Intrinsic::coro_promise);
@@ -3208,7 +3208,15 @@ void LLVMVisitor::visit(const CallInstr *x) {
   }
 
   auto *funcType = getLLVMFuncType(x->getCallee()->getType());
-  value = call({funcType, f}, args);
+  auto *callResult = call({funcType, f}, args);
+
+  auto *resultType = getLLVMType(x->getType());
+  if (!isStorableType(resultType)) {
+    value = getDummyValue(resultType);
+    return;
+  }
+
+  value = callResult;
 }
 
 void LLVMVisitor::visit(const TypePropertyInstr *x) {

--- a/codon/cir/llvm/llvisitor.h
+++ b/codon/cir/llvm/llvisitor.h
@@ -222,6 +222,8 @@ private:
     funcs.emplace(func->getId(), x);
   }
   llvm::Value *getDummyVoidValue() { return llvm::ConstantTokenNone::get(*context); }
+  bool isStorableType(llvm::Type *type);
+  llvm::Value *getDummyValue(llvm::Type *type);
   llvm::DISubprogram *getDISubprogramForFunc(const Func *x);
   void clearLLVMData();
 


### PR DESCRIPTION
fixes #844 

## Change
This change treats LLVM values with allocation size 0 as non-storable during LLVM lowering.

The call or expression is still emitted so side effects are preserved, but its zero-sized result is replaced with a dummy value such as undef {} instead of being carried as a live SSA value.

Important affected paths:
- CallInstr: emit the call, but use a dummy result for zero-sized return types.
- AssignInstr: evaluate RHS, but skip the store for non-storable result types.
- VarValue: return a dummy value instead of loading zero-sized storage.
- ForFlow: avoid storing/reloading zero-sized yielded values.
- globals / function locals: avoid allocating real storage for zero-sized values.

## MRE Result
```
  %24 = call {} @"std.asyncio._promise.0:0[Generator[NoneType]].10717"(ptr %23), !dbg !22315
  %25 = load ptr, ptr @"..default.std.internal.builtin.print.0:0.file", align 8, !dbg !22317
  %26 = call {} @"std.internal.builtin.print.0:0[Tuple[NoneType,NoneType],str,str,Ptr[UInt[8]],bool].1178"({ {}, {} } undef, { ptr, i64 } { ptr @.str.54, i64 1 }, { ptr, i64 } { ptr @.str.55, i64 1 }, ptr %25, i8 0), !dbg !22318
```
```bash
$ codon run mre.py 
b
c
None None
```
<img width="496" height="72" alt="image" src="https://github.com/user-attachments/assets/eae9d428-caf1-42a2-ad17-ddfe1c3eefe3" />
