### PR TITLE
Fix attribute assignment on `pyobj` objects

### DIFF
--- a/codon/parser/visitors/typecheck/assign.cpp
+++ b/codon/parser/visitors/typecheck/assign.cpp
@@ -399,6 +399,15 @@ void TypecheckVisitor::visit(AssignMemberStmt *stmt) {
           stmt->getRhs()));
       return;
     }
+    // Case: transform `pyobj.member = value` to `pyobj._setattr("member", value)`.
+    // Mirrors the read path in @c getClassMember, deferring the attribute write to
+    // CPython at runtime.
+    if (!member && lhsClass->is("pyobj")) {
+      resultStmt = transform(
+          N<ExprStmt>(N<CallExpr>(N<DotExpr>(stmt->getLhs(), "_setattr"),
+                                  N<StringExpr>(stmt->getMember()), stmt->getRhs())));
+      return;
+    }
     // Case: __setattr__ support. Ensure that only Literal[str] arguments are accepted.
     if (!member) {
       auto u = instantiateUnbound(), v = instantiateUnbound();

--- a/stdlib/internal/python.codon
+++ b/stdlib/internal/python.codon
@@ -101,7 +101,7 @@ PyObject_HasAttrString = Function[[cobj, cobj], int](cobj())
 PyObject_IsTrue = Function[[cobj], i32](cobj())
 PyObject_Length = Function[[cobj], int](cobj())
 PyObject_LengthHint = Function[[cobj, int], int](cobj())
-PyObject_SetAttrString = Function[[cobj, cobj, cobj], cobj](cobj())
+PyObject_SetAttrString = Function[[cobj, cobj, cobj], i32](cobj())
 PyObject_Str = Function[[cobj], cobj](cobj())
 PyObject_Repr = Function[[cobj], cobj](cobj())
 PyObject_Hash = Function[[cobj], int](cobj())
@@ -567,7 +567,7 @@ def init_handles_static():
     from C import PyObject_IsTrue(cobj) -> i32 as _PyObject_IsTrue
     from C import PyObject_Length(cobj) -> int as _PyObject_Length
     from C import PyObject_LengthHint(cobj, int) -> int as _PyObject_LengthHint
-    from C import PyObject_SetAttrString(cobj, cobj, cobj) -> cobj as _PyObject_SetAttrString
+    from C import PyObject_SetAttrString(cobj, cobj, cobj) -> i32 as _PyObject_SetAttrString
     from C import PyObject_Str(cobj) -> cobj as _PyObject_Str
     from C import PyObject_Repr(cobj) -> cobj as _PyObject_Repr
     from C import PyObject_Hash(cobj) -> int as _PyObject_Hash
@@ -1035,6 +1035,13 @@ class pyobj:
 
     def _getattr(self, name: str) -> pyobj:
         return pyobj(pyobj.exc_wrap(PyObject_GetAttrString(self.p, name.c_str())), steal=True)
+
+    def _setattr(self, name: str, val):
+        v = val.__to_py__()
+        try:
+            pyobj.exc_wrap(PyObject_SetAttrString(self.p, name.c_str(), v))
+        finally:
+            pyobj.decref(v)
 
     def exc_wrap(retval: T, T: type) -> T:
         if T is cobj:

--- a/test/python/mymodule.py
+++ b/test/python/mymodule.py
@@ -19,3 +19,10 @@ def test_call_no_args():
 
 def test_call_one_arg(x):
     return x**2
+
+class Box:
+    def __init__(self, value):
+        self.value = value
+class Frozen:
+    def __setattr__(self, name, value):
+        raise ValueError('frozen')

--- a/test/python/pybridge.codon
+++ b/test/python/pybridge.codon
@@ -40,6 +40,26 @@ def test_pythrow():
 test_pythrow()
 
 @test
+def test_pysetattr():
+    from python import mymodule
+    # Set an existing attribute and read it back through the pyobj boundary.
+    box = mymodule.Box(1)
+    box.value = 42
+    assert int.__from_py__(box._getattr('value').p) == 42
+    # Create a brand-new attribute.
+    box.extra = 7
+    assert int.__from_py__(box._getattr('extra').p) == 7
+    # A failing __setattr__ must surface the real Python exception, not be swallowed.
+    frozen = mymodule.Frozen()
+    try:
+        frozen.value = 1
+    except PyError as e:
+        assert e.message == "frozen"
+        return
+    assert False
+test_pysetattr()
+
+@test
 def test_pyargs():
     from python import mymodule
     assert str(mymodule.print_args_var(1, 2, 3)) == "a=1, b=2, c=3, args=(), kwargs={}"


### PR DESCRIPTION
Fix an issue where setting attributes on `pyobj` objects would fail. Previously, attribute assignment (e.g., `obj.attr = value`) on `pyobj` instances did not work correctly. This PR resolves the issue so that attribute writes propagate as expected.
