### PR TITLE
[TypeCheck] Add guard for sealing Union

### DIFF
--- a/codon/parser/visitors/typecheck/op.cpp
+++ b/codon/parser/visitors/typecheck/op.cpp
@@ -505,14 +505,16 @@ void TypecheckVisitor::visit(InstantiateExpr *expr) {
           E(Error::EXPECTED_TYPE, (*expr)[i], "type");
       }
       if (isUnion) {
-        if (!typ->getUnion()->addType(t.get()))
-          E(error::Error::UNION_TOO_BIG, (*expr)[i],
-            typ->getUnion()->pendingTypes.size());
+        if (!typ->getUnion()->isSealed()) {
+          if (!typ->getUnion()->addType(t.get()))
+            E(error::Error::UNION_TOO_BIG, (*expr)[i],
+              typ->getUnion()->pendingTypes.size());
+        }
       } else {
         unify(t.get(), generics[i].getType());
       }
     }
-    if (isUnion) {
+    if (isUnion && !typ->getUnion()->isSealed()) {
       typ->getUnion()->seal();
     }
 

--- a/test/parser/typecheck/test_op.codon
+++ b/test/parser/typecheck/test_op.codon
@@ -129,6 +129,21 @@ print fx(2) #: 3
 fxx: Function[[int], int] = foo
 print fxx(3) #: 4
 
+#%% index_union_annotation_revisit,barebones
+class IndexUnionA:
+    pass
+
+class IndexUnionB:
+    pass
+
+class IndexUnionTemplate[T]:
+    pass
+
+def index_union_arg(t: Union[IndexUnionTemplate[IndexUnionA], IndexUnionTemplate[IndexUnionB]]):
+    print("ok")
+
+index_union_arg(IndexUnionTemplate[IndexUnionA]())  #: ok
+
 #%% index_special,barebones
 class Foo:
     def __getitem__(self, foo):


### PR DESCRIPTION
fixes #853 

## Changes
- Add a guard in` op.cpp `
- Add a regression test in test_op.codon for Union typechecking with generic type 
